### PR TITLE
[OWL-370] Replace absolute path with relative path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(TARGET): $(TARGET_SOURCE)
 	go build -o open-falcon
 
 $(BIN):
-	go build -o $@ github.com/Cepave/open-falcon/modules/$(@:bin/falcon-%=%)
+	go build -o $@ ./modules/$(@:bin/falcon-%=%)
 
 # dev creates binaries for testing locally - these are put into ./bin and $GOPATH
 dev: format
@@ -58,7 +58,7 @@ bin/falcon-sender : $(shell find modules/sender/ -name '*.go')
 bin/falcon-task : $(shell find modules/task/ -name '*.go')
 bin/falcon-transfer : $(shell find modules/transfer/ -name '*.go')
 bin/falcon-fe: $(shell find modules/fe/ -name '*.go')
-	go build -o $@ github.com/Cepave/open-falcon/modules/$(@:bin/falcon-%=%)
+	go build -o $@ ./modules/$(@:bin/falcon-%=%)
 	mkdir -p bin/fe
 	cp -r modules/fe/{control,cfg.example.json,conf,static,views,scripts} bin/fe/
 	cp bin/falcon-fe bin/fe/falcon-fe


### PR DESCRIPTION
In the `go build` command, replace `github.com/Cepave/open-falcon` with `.`.