### PR TITLE
[OWL-509][fe] improve plugin state summary page

### DIFF
--- a/modules/fe/http/dashboard/dashboard_controller.go
+++ b/modules/fe/http/dashboard/dashboard_controller.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/Cepave/open-falcon-backend/modules/fe/http/base"
 	"github.com/Cepave/open-falcon-backend/modules/fe/model/dashboard"
 	"github.com/Cepave/open-falcon-backend/modules/fe/model/uic"
+	"github.com/SlyMarbo/rss"
 )
 
 type DashBoardController struct {
@@ -211,10 +213,11 @@ func (this *DashBoardController) EndpRegxquryForOps() {
 	if queryStr == "" || this.Data["SessionFlag"] == true {
 		this.Data["Init"] = true
 	} else {
-		enp, _ := dashboard.QueryEndpintByNameRegxForOps(queryStr)
+		enpRow, _ := dashboard.QueryEndpintByNameRegxForOps(queryStr)
+		enp := gitInfoAdapter(enpRow)
 		if len(enp) > 0 {
 			var ips []string
-			this.Data["Endopints"] = enp
+			this.Data["Endpoints"] = enp
 			this.Data["Len"] = len(enp)
 			for _, en := range enp {
 				if en.Ip != "" {
@@ -223,10 +226,46 @@ func (this *DashBoardController) EndpRegxquryForOps() {
 			}
 			this.Data["IP"] = strings.Join(ips, ",")
 		} else {
-			this.Data["Endopints"] = []string{}
+			this.Data["Endpoints"] = []string{}
 			this.Data["Len"] = 0
 			this.Data["IP"] = ""
 		}
 	}
 	this.TplName = "dashboard/endpoints.html"
+}
+
+var commitsInfo []*rss.Item
+
+func gitInfoAdapter(enpRow []dashboard.Hosts) (enp []dashboard.GitInfo) {
+	feed, err := rss.Fetch("https://gitlab.com/Cepave/OwlPlugin/commits/master.atom")
+	if err != nil {
+		log.Println(err)
+	}
+
+	commitsInfo = append(commitsInfo, feed.Items...)
+	log.Println("commit atom feed is:", feed.Items)
+	log.Println("commitsInfo is:", commitsInfo)
+	for _, host := range enpRow {
+		//log.Println("host data is:", host)
+		gitInfo := dashboard.GitInfo{Hostname: host.Hostname,
+			Ip:            host.Ip,
+			AgentVersion:  host.AgentVersion,
+			PluginVersion: host.PluginVersion,
+			Valid:         false}
+		for _, item := range commitsInfo {
+			titleArray := strings.Split(item.ID, "/")
+			hash := strings.TrimSpace(titleArray[len(titleArray)-1])
+			if hash == host.PluginVersion {
+				// copy Title and Date column
+				gitInfo.Date = item.Date
+				gitInfo.Title = item.Title
+				gitInfo.Valid = true
+				break
+			}
+		}
+		//log.Println("gitInfo is: ", gitInfo)
+		enp = append(enp, gitInfo)
+	}
+
+	return
 }

--- a/modules/fe/http/dashboard/dashboard_controller.go
+++ b/modules/fe/http/dashboard/dashboard_controller.go
@@ -192,6 +192,40 @@ func (this *DashBoardController) CountNumOfHostGroup() {
 	return
 }
 
+func (this *DashBoardController) EndpRegxquryForPlugin() {
+	baseResp := this.BasicRespGen()
+	session, err := this.SessionCheck()
+	if err != nil {
+		this.ResposeError(baseResp, err.Error())
+		return
+	}
+	var username *uic.User
+	if session.Uid <= 0 {
+		baseResp.Data["SessionFlag"] = true
+		baseResp.Data["ErrorMsg"] = "Session is not vaild"
+	} else {
+		baseResp.Data["SessionFlag"] = false
+		username = uic.SelectUserById(session.Uid)
+		if username.Name != "root" {
+			baseResp.Data["SessionFlag"] = true
+			baseResp.Data["ErrorMsg"] = "You don't have permission to access this page"
+		}
+	}
+	queryStr := ".+"
+	if baseResp.Data["SessionFlag"] == false {
+		enpRow, _ := dashboard.QueryEndpintByNameRegxForOps(queryStr)
+		enp := gitInfoAdapter(enpRow)
+		if len(enp) > 0 {
+			baseResp.Data["Endpoints"] = enp
+		} else {
+			baseResp.Data["Endpoints"] = []string{}
+		}
+	}
+	log.Println(baseResp)
+	this.ServeApiJson(baseResp)
+	return
+}
+
 func (this *DashBoardController) EndpRegxquryForOps() {
 	this.Data["Shortcut"] = g.Config().Shortcut
 	sig := this.Ctx.GetCookie("sig")

--- a/modules/fe/http/dashboard/dashboard_routes.go
+++ b/modules/fe/http/dashboard/dashboard_routes.go
@@ -13,6 +13,7 @@ func ConfigRoutes() {
 		}),
 		beego.NSRouter("/endpoints", &DashBoardController{}, "get:EndpRegxqury;post:EndpRegxqury"),
 		beego.NSRouter("/endpointcounters", &DashBoardController{}, "get:CounterQuery;post:CounterQuery"),
+		beego.NSRouter("/endpointplugins", &DashBoardController{}, "get:EndpRegxquryForPlugin;post:EndpRegxquryForPlugin"),
 	)
 	hostgroup := beego.NewNamespace("/api/v1/hostgroup",
 		beego.NSGet("/notallowed", func(ctx *context.Context) {

--- a/modules/fe/model/dashboard/models.go
+++ b/modules/fe/model/dashboard/models.go
@@ -47,3 +47,13 @@ type HostGroupMapping struct {
 	GrpId  int64 `json:"grp_id"`
 	HostId int64 `json:"host_id"`
 }
+
+type GitInfo struct {
+	Hostname      string    `json:"hostname"`
+	Ip            string    `json:"ip"`
+	AgentVersion  string    `json:"agent_version"`
+	PluginVersion string    `json:"plugin_version"`
+	Title         string    `json:"title"`
+	Date          time.Time `json:"commit_at"`
+	Valid         bool      `json:"valid"`
+}

--- a/modules/fe/views/dashboard/endpoints.html
+++ b/modules/fe/views/dashboard/endpoints.html
@@ -26,15 +26,19 @@ new Clipboard('#clip');
         <th>IP</th>
         <th>AgentVersion</th>
         <th>PluginVersion</th>
+        <th>Date</th>
+        <th>Title</th>
         </tr>
       </thead>
       <tbody>
-        {{range .Endopints}}
+        {{range .Endpoints}}
           <tr>
           <td>{{.Hostname}}</td>
           <td id="ip">{{.Ip}}</td>
           <td>{{.AgentVersion}}</td>
           <td>{{.PluginVersion}}</td>
+          <td>{{.Date}}</td>
+          <td>{{.Title}}</td>
           </tr>
         {{end}}
       </tbody>


### PR DESCRIPTION
Original plugin state summary page has only git commit hash. 
In this patch, column date and title are added into this page. Therefore, this page has more git information. 