### PR TITLE
[OWL-253][common] Fix the path problem

### DIFF
--- a/common/vipercfg/vipercfg.go
+++ b/common/vipercfg/vipercfg.go
@@ -2,35 +2,19 @@ package vipercfg
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/chyeh/viper"
 	"github.com/spf13/pflag"
 )
 
 var v = viper.New()
 
-func rmFileExt(filename string) string {
-	return strings.TrimSuffix(filename, filepath.Ext(filename))
-}
-
 func Load() {
 	cfgPath := v.GetString("config")
-	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
-		log.Fatalln("Configuration file [", cfgPath, "] doesn't exist")
-	}
-
-	v.SetConfigName(rmFileExt(cfgPath))
-
-	v.AddConfigPath(".")
-
+	v.SetConfigFile(cfgPath)
 	err := v.ReadInConfig()
 	if err != nil {
 		log.Fatalln("Error:", err)
 	}
-
 }
 
 func Parse() {


### PR DESCRIPTION
Substituting `SetConfigFile()` for `SetConfigName()` solved the problem of getting wrong configuration file path.