### PR TITLE
[OWL-791][fe] add new API to support probing running plugins

### DIFF
--- a/modules/fe/http/dashboard/dashboard_routes.go
+++ b/modules/fe/http/dashboard/dashboard_routes.go
@@ -14,6 +14,7 @@ func ConfigRoutes() {
 		beego.NSRouter("/endpoints", &DashBoardController{}, "get:EndpRegxqury;post:EndpRegxqury"),
 		beego.NSRouter("/endpointcounters", &DashBoardController{}, "get:CounterQuery;post:CounterQuery"),
 		beego.NSRouter("/endpointplugins", &DashBoardController{}, "get:EndpRegxquryForPlugin;post:EndpRegxquryForPlugin"),
+		beego.NSRouter("/endpointrunningplugins", &DashBoardController{}, "get:EndpRunningPlugin;post:EndpRunningPlugin"),
 	)
 	hostgroup := beego.NewNamespace("/api/v1/hostgroup",
 		beego.NSGet("/notallowed", func(ctx *context.Context) {

--- a/modules/fe/http/dashboard/dashboard_routes.go
+++ b/modules/fe/http/dashboard/dashboard_routes.go
@@ -15,6 +15,7 @@ func ConfigRoutes() {
 		beego.NSRouter("/endpointcounters", &DashBoardController{}, "get:CounterQuery;post:CounterQuery"),
 		beego.NSRouter("/endpointplugins", &DashBoardController{}, "get:EndpRegxquryForPlugin;post:EndpRegxquryForPlugin"),
 		beego.NSRouter("/endpointrunningplugins", &DashBoardController{}, "get:EndpRunningPlugin;post:EndpRunningPlugin"),
+		beego.NSRouter("/latestplugin", &DashBoardController{}, "get:LatestPlugin;post:LatestPlugin"),
 	)
 	hostgroup := beego.NewNamespace("/api/v1/hostgroup",
 		beego.NSGet("/notallowed", func(ctx *context.Context) {


### PR DESCRIPTION
The new API ```endpointrunningplugins``` will probe agent's current running plugins. This API can help to debug when we want to fully be sure that certain plugins are running on some hosts or not. 