### PR TITLE
[OWL-627][fe] API for query endpoints by counter

### DIFF
--- a/modules/fe/http/dashboard/dashboard_controller.go
+++ b/modules/fe/http/dashboard/dashboard_controller.go
@@ -111,6 +111,36 @@ func (this *DashBoardController) CounterQuery() {
 	return
 }
 
+//endpoints query by counter
+func (this *DashBoardController) EndpointQuery() {
+	baseResp := this.BasicRespGen()
+	_, err := this.SessionCheck()
+	if err != nil {
+		this.ResposeError(baseResp, err.Error())
+		return
+	}
+	counter := this.GetString("counter", "")
+	limitNum, _ := this.GetInt("limit", 0)
+	metricQuery := this.GetString("metricQuery", "")
+	negateMatch, _ := this.GetBool("negateMatch", false)
+	if metricQuery == "" && counter == "" {
+		this.ResposeError(baseResp, "query string && query pattern are both empty, please check it")
+		return
+	}
+	endpoints, err := dashboard.QueryEndpointsByCounter(counter, limitNum, metricQuery, negateMatch)
+	switch {
+	case err != nil:
+		this.ResposeError(baseResp, err.Error())
+		return
+	case len(endpoints) == 0:
+		baseResp.Data["endpoints"] = []string{}
+	default:
+		baseResp.Data["endpoints"] = endpoints
+	}
+	this.ServeApiJson(baseResp)
+	return
+}
+
 func (this *DashBoardController) HostGroupQuery() {
 	baseResp := this.BasicRespGen()
 	_, err := this.SessionCheck()

--- a/modules/fe/http/dashboard/dashboard_routes.go
+++ b/modules/fe/http/dashboard/dashboard_routes.go
@@ -16,6 +16,7 @@ func ConfigRoutes() {
 		beego.NSRouter("/endpointplugins", &DashBoardController{}, "get:EndpRegxquryForPlugin;post:EndpRegxquryForPlugin"),
 		beego.NSRouter("/endpointrunningplugins", &DashBoardController{}, "get:EndpRunningPlugin;post:EndpRunningPlugin"),
 		beego.NSRouter("/latestplugin", &DashBoardController{}, "get:LatestPlugin;post:LatestPlugin"),
+		beego.NSRouter("/counterendpoints", &DashBoardController{}, "get:EndpointQuery;post:EndpointQuery"),
 	)
 	hostgroup := beego.NewNamespace("/api/v1/hostgroup",
 		beego.NSGet("/notallowed", func(ctx *context.Context) {

--- a/modules/fe/model/dashboard/endpoint_counter.go
+++ b/modules/fe/model/dashboard/endpoint_counter.go
@@ -3,9 +3,10 @@ package dashboard
 import (
 	"errors"
 	"fmt"
+	"regexp"
+
 	"github.com/Cepave/open-falcon-backend/modules/fe/g"
 	"github.com/astaxie/beego/orm"
-	"regexp"
 )
 
 func QueryEndpointidbyNames(endpoints []string, limit int) (enp []Endpoint, err error) {
@@ -15,6 +16,34 @@ func QueryEndpointidbyNames(endpoints []string, limit int) (enp []Endpoint, err 
 	qb, _ := orm.NewQueryBuilder("mysql")
 	qt := qb.Select("*").From("endpoint").Where("endpoint").In(endpoints...).Limit(limit)
 	_, err = q.Raw(qt.String()).QueryRows(&enp)
+	return
+}
+
+func QueryEndpointsByCounter(counter string, limit int, metricQuery string, negatePattern bool) (endpoints []string, err error) {
+	config := g.Config()
+	if limit == 0 || limit > config.GraphDB.Limit {
+		limit = config.GraphDB.Limit
+	}
+
+	q := orm.NewOrm()
+	q.Using("graph")
+	q.QueryTable("endpoint_counter")
+	var queryprefix string
+	if metricQuery == "" {
+		queryprefix = fmt.Sprintf("select endpoint from endpoint as table1 inner join (select distinct endpoint_id from endpoint_counter where counter = '%s') as table2 where table1.id = table2.endpoint_id limit %d", counter, limit)
+	} else {
+		var negate string
+		if negatePattern {
+			negate = "not"
+		}
+		queryprefix = fmt.Sprintf("select endpoint from endpoint as table1 inner join (select distinct endpoint_id from endpoint_counter where counter %s regexp '%s') as table2 where table1.id = table2.endpoint_id limit %d", negate, metricQuery, limit)
+	}
+	var enp []Endpoint
+	_, err = q.Raw(queryprefix).QueryRows(&enp)
+	for _, v := range enp {
+		endpoints = append(endpoints, v.Endpoint)
+	}
+
 	return
 }
 


### PR DESCRIPTION
[OWL-627][fe] API for query endpoints by counter

provide new API api/v1/dashboard/counterendpoints which has two mode to use it. 
 
1. use the parameter **counter**.
In this mode, this API can retrieve all the endpoints that have certain counter. 
2. use the parameter **metricQuery**, with **negateMatch**=true or false.
In this mode, this API can retrieve all the endpoint match or not match certain counter pattern.