### PR TITLE
[OWL-890][fe] move the hardcoded address to config

### DIFF
--- a/modules/fe/cfg.example.json
+++ b/modules/fe/cfg.example.json
@@ -18,6 +18,7 @@
         }
     },
     "salt": "",
+    "atomAddress": "https://example.com/Cepave/OwlPlugin/commits/master.atom",
     "canRegister": true,
     "ldap": {
         "enabled": false,

--- a/modules/fe/g/cfg.go
+++ b/modules/fe/g/cfg.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
-
 	"github.com/toolkits/file"
 )
 
@@ -106,6 +105,7 @@ type GlobalConfig struct {
 	Cache        *CacheConfig        `json:"cache"`
 	Http         *HttpConfig         `json:"http"`
 	Salt         string              `json:"salt"`
+	AtomAddr     string              `json:"atomAddress"`
 	CanRegister  bool                `json:"canRegister"`
 	Ldap         *LdapConfig         `json:"ldap"`
 	Uic          *UicConfig          `json:"uic"`

--- a/modules/fe/http/dashboard/dashboard_controller.go
+++ b/modules/fe/http/dashboard/dashboard_controller.go
@@ -66,7 +66,7 @@ func (this *DashBoardController) LatestPlugin() {
 	}
 
 	v := xmlData{}
-	if resp, err := http.Get("https://gitlab.com/Cepave/OwlPlugin/commits/master.atom"); err != nil {
+	if resp, err := http.Get(g.Config().AtomAddr); err != nil {
 		// handle error.
 		log.Println("Error retrieving resource:", err)
 	} else {
@@ -361,7 +361,7 @@ func (this *DashBoardController) EndpRegxquryForOps() {
 var commitsInfo []*rss.Item
 
 func gitInfoAdapter(enpRow []dashboard.Hosts) (enp []dashboard.GitInfo) {
-	feed, err := rss.Fetch("https://gitlab.com/Cepave/OwlPlugin/commits/master.atom")
+	feed, err := rss.Fetch(g.Config().AtomAddr)
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
Move the hardcoded address to config file. 

`https://gitlab.com/Cepave/OwlPlugin/commits/master.atom` will now be stored in variable `g.Config().AtomAddr`