### PR TITLE
[OWL-867][agent][hbs][common] HBS policy includes git update and git repo update info 

### DIFF
--- a/common/model/agent.go
+++ b/common/model/agent.go
@@ -42,13 +42,17 @@ func (this *AgentHeartbeatRequest) String() string {
 type AgentPluginsResponse struct {
 	Plugins   []string
 	Timestamp int64
+	GitRepo   string
+	GitUpdate bool
 }
 
 func (this *AgentPluginsResponse) String() string {
 	return fmt.Sprintf(
-		"<Plugins:%v, Timestamp:%v>",
+		"<Plugins:%v, Timestamp:%v, GitRepo:%v, GitUpdate:%v>",
 		this.Plugins,
 		this.Timestamp,
+		this.GitRepo,
+		this.GitUpdate,
 	)
 }
 

--- a/common/model/agent.go
+++ b/common/model/agent.go
@@ -9,6 +9,7 @@ type AgentReportRequest struct {
 	IP            string
 	AgentVersion  string
 	PluginVersion string
+	GitRepo       string
 }
 
 func (this *AgentReportRequest) String() string {
@@ -40,19 +41,21 @@ func (this *AgentHeartbeatRequest) String() string {
 }
 
 type AgentPluginsResponse struct {
-	Plugins   []string
-	Timestamp int64
-	GitRepo   string
-	GitUpdate bool
+	Plugins       []string
+	Timestamp     int64
+	GitRepo       string
+	GitUpdate     bool
+	GitRepoUpdate bool
 }
 
 func (this *AgentPluginsResponse) String() string {
 	return fmt.Sprintf(
-		"<Plugins:%v, Timestamp:%v, GitRepo:%v, GitUpdate:%v>",
+		"<Plugins:%v, Timestamp:%v, GitRepo:%v, GitUpdate:%v, GitRepoUpdate:%v>",
 		this.Plugins,
 		this.Timestamp,
 		this.GitRepo,
 		this.GitUpdate,
+		this.GitRepoUpdate,
 	)
 }
 

--- a/modules/agent/cron/plugin.go
+++ b/modules/agent/cron/plugin.go
@@ -1,12 +1,15 @@
 package cron
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/Cepave/open-falcon-backend/common/model"
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
 	"github.com/Cepave/open-falcon-backend/modules/agent/plugins"
 	log "github.com/Sirupsen/logrus"
-	"strings"
-	"time"
 )
 
 func SyncMinePlugins() {
@@ -59,6 +62,14 @@ func syncMinePlugins() {
 
 		pluginDirs = resp.Plugins
 		timestamp = resp.Timestamp
+		plugins.GitRepo = resp.GitRepo
+
+		if resp.GitUpdate {
+			addr := fmt.Sprintf("http://127.0.0.1%s/plugin/update", g.Config().Http.Listen)
+			log.Println("GitUpdate API address is: ", addr)
+			apiResp, _ := http.Get(addr)
+			log.Println(&apiResp)
+		}
 
 		if g.Config().Debug {
 			log.Println(&resp)

--- a/modules/agent/cron/plugin.go
+++ b/modules/agent/cron/plugin.go
@@ -56,6 +56,7 @@ func syncMinePlugins() {
 			continue
 		}
 
+		log.Println("Agent.MinePlugins content is:", resp)
 		if resp.Timestamp <= timestamp {
 			continue
 		}

--- a/modules/agent/cron/plugin.go
+++ b/modules/agent/cron/plugin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Cepave/open-falcon-backend/common/model"
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
+	localHttp "github.com/Cepave/open-falcon-backend/modules/agent/http"
 	"github.com/Cepave/open-falcon-backend/modules/agent/plugins"
 	log "github.com/Sirupsen/logrus"
 )
@@ -56,7 +57,6 @@ func syncMinePlugins() {
 			continue
 		}
 
-		log.Println("Agent.MinePlugins content is:", resp)
 		if resp.Timestamp <= timestamp {
 			continue
 		}
@@ -65,7 +65,10 @@ func syncMinePlugins() {
 		timestamp = resp.Timestamp
 		plugins.GitRepo = resp.GitRepo
 
-		if resp.GitUpdate {
+		if resp.GitRepoUpdate {
+			log.Println("GitRepo updating ... ")
+			localHttp.DeleteAndCloneRepo(g.Config().Plugin.Dir, plugins.GitRepo)
+		} else if resp.GitUpdate {
 			addr := fmt.Sprintf("http://127.0.0.1%s/plugin/update", g.Config().Http.Listen)
 			log.Println("GitUpdate API address is: ", addr)
 			apiResp, _ := http.Get(addr)

--- a/modules/agent/cron/reporter.go
+++ b/modules/agent/cron/reporter.go
@@ -2,10 +2,11 @@ package cron
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/Cepave/open-falcon-backend/common/model"
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
 	log "github.com/Sirupsen/logrus"
-	"time"
 )
 
 func ReportAgentStatus() {
@@ -26,6 +27,7 @@ func reportAgentStatus(interval time.Duration) {
 			IP:            g.IP(),
 			AgentVersion:  g.VERSION,
 			PluginVersion: g.GetCurrPluginVersion(),
+			GitRepo:       g.GetCurrGitRepo(),
 		}
 
 		var resp model.SimpleRpcResponse

--- a/modules/agent/g/cfg.go
+++ b/modules/agent/g/cfg.go
@@ -13,7 +13,6 @@ import (
 type PluginConfig struct {
 	Enabled bool   `json:"enabled"`
 	Dir     string `json:"dir"`
-	Git     string `json:"git"`
 	LogDir  string `json:"logs"`
 }
 

--- a/modules/agent/g/tool.go
+++ b/modules/agent/g/tool.go
@@ -3,9 +3,10 @@ package g
 import (
 	"bytes"
 	"fmt"
-	"github.com/toolkits/file"
 	"os/exec"
 	"strings"
+
+	"github.com/toolkits/file"
 )
 
 func GetCurrPluginVersion() string {
@@ -19,6 +20,29 @@ func GetCurrPluginVersion() string {
 	}
 
 	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = pluginDir
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Sprintf("Error:%s", err.Error())
+	}
+
+	return strings.TrimSpace(out.String())
+}
+
+func GetCurrGitRepo() string {
+	if !Config().Plugin.Enabled {
+		return "plugin not enabled"
+	}
+
+	pluginDir := Config().Plugin.Dir
+	if !file.IsExist(pluginDir) {
+		return "plugin dir not existent"
+	}
+
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
 	cmd.Dir = pluginDir
 
 	var out bytes.Buffer

--- a/modules/agent/http/plugin.go
+++ b/modules/agent/http/plugin.go
@@ -12,7 +12,7 @@ import (
 	"github.com/toolkits/file"
 )
 
-func deleteAndCloneRepo(pluginDir string, gitRemoteAddr string) (out string) {
+func DeleteAndCloneRepo(pluginDir string, gitRemoteAddr string) (out string) {
 	parentDir := file.Dir(pluginDir)
 
 	absPath, _ := filepath.Abs(pluginDir)
@@ -56,7 +56,7 @@ func configPluginRoutes() {
 			err := cmd.Run()
 			if err != nil {
 				w.Write([]byte(fmt.Sprintf("git pull in dir:%s fail. error: %s", dir, err)))
-				w.Write([]byte(deleteAndCloneRepo(dir, g.Config().Plugin.Git)))
+				w.Write([]byte(DeleteAndCloneRepo(dir, plugins.GitRepo)))
 				return
 			}
 		} else {

--- a/modules/agent/http/plugin.go
+++ b/modules/agent/http/plugin.go
@@ -61,7 +61,7 @@ func configPluginRoutes() {
 			}
 		} else {
 			// git clone
-			cmd := exec.Command("git", "clone", g.Config().Plugin.Git, file.Basename(dir))
+			cmd := exec.Command("git", "clone", plugins.GitRepo, file.Basename(dir))
 			cmd.Dir = parentDir
 			err := cmd.Run()
 			if err != nil {

--- a/modules/agent/plugins/plugins.go
+++ b/modules/agent/plugins/plugins.go
@@ -9,6 +9,7 @@ type Plugin struct {
 var (
 	Plugins              = make(map[string]*Plugin)
 	PluginsWithScheduler = make(map[string]*PluginScheduler)
+	GitRepo              string
 )
 
 func DelNoUsePlugins(newPlugins map[string]*Plugin) {

--- a/modules/hbs/cache/cache.go
+++ b/modules/hbs/cache/cache.go
@@ -1,8 +1,9 @@
 package cache
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 func Init() {
@@ -38,7 +39,7 @@ func Init() {
 	log.Println("cache done")
 
 	go LoopInit()
-
+	go getNewestPluginHash()
 }
 
 func LoopInit() {

--- a/modules/hbs/cache/gitupdate.go
+++ b/modules/hbs/cache/gitupdate.go
@@ -15,7 +15,7 @@ func GitRepoUpdateCheck(hostname string) bool {
 	if agentUpdateInfo, ok := Agents.Get(hostname); ok {
 		hostGitRepo := agentUpdateInfo.ReportRequest.GitRepo
 		currGitRepo := g.Config().GitRepo
-		log.Println("host GitRepo of ", hostname, hostGitRepo)
+		log.Debugln("host GitRepo of ", hostname, hostGitRepo)
 		return (hostGitRepo != currGitRepo)
 	}
 
@@ -26,8 +26,8 @@ func GitUpdateCheck(hostname string) bool {
 	if agentUpdateInfo, ok := Agents.Get(hostname); ok {
 		hostPluginVersion := agentUpdateInfo.ReportRequest.PluginVersion
 		newestPluginVersion := pluginHash.Get()
-		log.Println("hostPluginVersion of ", hostname, hostPluginVersion)
-		log.Println("newestPluginVersion is:", newestPluginVersion)
+		log.Debugln("hostPluginVersion of ", hostname, hostPluginVersion)
+		log.Debugln("newestPluginVersion is:", newestPluginVersion)
 		return (hostPluginVersion != newestPluginVersion)
 	}
 
@@ -82,8 +82,8 @@ func getNewestPluginHash() {
 			strlist := strings.Split(v.EntryList[0].ID, "/")
 			hash := strlist[len(strlist)-1]
 			pluginHash.Put(hash)
-			log.Println("Get newest plugin hash from atomAddr:", atomAddr)
-			log.Println("Record newest hash as:", hash)
+			log.Debugln("Get newest plugin hash from atomAddr:", atomAddr)
+			log.Debugln("Record newest hash as:", hash)
 		}
 	}
 }

--- a/modules/hbs/cache/gitupdate.go
+++ b/modules/hbs/cache/gitupdate.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Cepave/open-falcon-backend/modules/hbs/g"
+	log "github.com/Sirupsen/logrus"
+)
+
+func GitUpdateCheck(hostname string) bool {
+	if agentUpdateInfo, ok := Agents.Get(hostname); ok {
+		hostPluginVersion := agentUpdateInfo.ReportRequest.PluginVersion
+		newestPluginVersion := pluginHash.Get()
+		log.Println("hostPluginVersion of ", hostname, hostPluginVersion)
+		log.Println("newestPluginVersion is:", newestPluginVersion)
+		return (hostPluginVersion != newestPluginVersion)
+	}
+
+	// need to update
+	return true
+}
+
+type SafePluginHash struct {
+	sync.RWMutex
+	hash string
+}
+
+func (this *SafePluginHash) Put(commitHash string) {
+	this.Lock()
+	defer this.Unlock()
+	this.hash = commitHash
+}
+
+func (this *SafePluginHash) Get() (commitHash string) {
+	this.RLock()
+	defer this.RUnlock()
+	commitHash = this.hash
+	return commitHash
+}
+
+var pluginHash = &SafePluginHash{hash: ""}
+
+type xmlEntry struct {
+	ID      string `xml:"id"`
+	Updated string `xml:"updated"`
+}
+
+type xmlData struct {
+	EntryList []xmlEntry `xml:"entry"`
+}
+
+func getNewestPluginHash() {
+	for {
+		time.Sleep(time.Minute)
+
+		v := xmlData{}
+		atomAddr := strings.Replace(g.Config().GitRepo, ".git", "/commits/master.atom", -1)
+		if resp, err := http.Get(atomAddr); err != nil {
+			// handle error.
+			log.Println("Error retrieving resource:", err)
+		} else {
+			defer resp.Body.Close()
+			xml.NewDecoder(resp.Body).Decode(&v)
+		}
+		if len(v.EntryList) > 0 {
+			// update newest Plugin hash
+			strlist := strings.Split(v.EntryList[0].ID, "/")
+			hash := strlist[len(strlist)-1]
+			pluginHash.Put(hash)
+			log.Println("Get newest plugin hash from atomAddr:", atomAddr)
+			log.Println("Record newest hash as:", hash)
+		}
+	}
+}

--- a/modules/hbs/cache/gitupdate.go
+++ b/modules/hbs/cache/gitupdate.go
@@ -11,6 +11,17 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+func GitRepoUpdateCheck(hostname string) bool {
+	if agentUpdateInfo, ok := Agents.Get(hostname); ok {
+		hostGitRepo := agentUpdateInfo.ReportRequest.GitRepo
+		currGitRepo := g.Config().GitRepo
+		log.Println("host GitRepo of ", hostname, hostGitRepo)
+		return (hostGitRepo != currGitRepo)
+	}
+
+	return true
+}
+
 func GitUpdateCheck(hostname string) bool {
 	if agentUpdateInfo, ok := Agents.Get(hostname); ok {
 		hostPluginVersion := agentUpdateInfo.ReportRequest.PluginVersion

--- a/modules/hbs/cache/gitupdate.go
+++ b/modules/hbs/cache/gitupdate.go
@@ -72,7 +72,7 @@ func getNewestPluginHash() {
 		atomAddr := strings.Replace(g.Config().GitRepo, ".git", "/commits/master.atom", -1)
 		if resp, err := http.Get(atomAddr); err != nil {
 			// handle error.
-			log.Println("Error retrieving resource:", err)
+			log.Errorln("Error retrieving resource:", err)
 		} else {
 			defer resp.Body.Close()
 			xml.NewDecoder(resp.Body).Decode(&v)

--- a/modules/hbs/cfg.example.json
+++ b/modules/hbs/cfg.example.json
@@ -9,5 +9,5 @@
         "enabled": true,
         "listen": "0.0.0.0:6031"
     },
-    "gitrepo": "https://gitlab.com/Cepave/OwlPlugin.git"
+    "gitrepo": "https://example.com/Cepave/OwlPlugin.git"
 }

--- a/modules/hbs/cfg.example.json
+++ b/modules/hbs/cfg.example.json
@@ -8,5 +8,6 @@
     "http": {
         "enabled": true,
         "listen": "0.0.0.0:6031"
-    }
+    },
+    "gitrepo": "https://gitlab.com/Cepave/OwlPlugin.git"
 }

--- a/modules/hbs/g/cfg.go
+++ b/modules/hbs/g/cfg.go
@@ -2,9 +2,10 @@ package g
 
 import (
 	"encoding/json"
+	"sync"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/toolkits/file"
-	"sync"
 )
 
 type HttpConfig struct {
@@ -20,6 +21,7 @@ type GlobalConfig struct {
 	Listen    string      `json:"listen"`
 	Trustable []string    `json:"trustable"`
 	Http      *HttpConfig `json:"http"`
+	GitRepo   string      `json:"gitrepo"`
 }
 
 var (

--- a/modules/hbs/rpc/agent.go
+++ b/modules/hbs/rpc/agent.go
@@ -19,6 +19,8 @@ func (t *Agent) MinePlugins(args model.AgentHeartbeatRequest, reply *model.Agent
 
 	reply.Plugins = cache.GetPlugins(args.Hostname)
 	reply.Timestamp = time.Now().Unix()
+	reply.GitRepo = "https://gitlab.com/Cepave/OwlPlugin.git"
+	reply.GitUpdate = true
 
 	return nil
 }

--- a/modules/hbs/rpc/agent.go
+++ b/modules/hbs/rpc/agent.go
@@ -19,8 +19,8 @@ func (t *Agent) MinePlugins(args model.AgentHeartbeatRequest, reply *model.Agent
 
 	reply.Plugins = cache.GetPlugins(args.Hostname)
 	reply.Timestamp = time.Now().Unix()
-	reply.GitRepo = "https://gitlab.com/Cepave/OwlPlugin.git"
-	reply.GitUpdate = true
+	reply.GitRepo = g.Config().GitRepo
+	reply.GitUpdate = cache.GitUpdateCheck(args.Hostname)
 
 	return nil
 }

--- a/modules/hbs/rpc/agent.go
+++ b/modules/hbs/rpc/agent.go
@@ -21,6 +21,7 @@ func (t *Agent) MinePlugins(args model.AgentHeartbeatRequest, reply *model.Agent
 	reply.Timestamp = time.Now().Unix()
 	reply.GitRepo = g.Config().GitRepo
 	reply.GitUpdate = cache.GitUpdateCheck(args.Hostname)
+	reply.GitRepoUpdate = cache.GitRepoUpdateCheck(args.Hostname)
 
 	return nil
 }


### PR DESCRIPTION
1. RPC Agent.ReportStatus  會對 HBS 送出

    1. git 最新的 commit hash 
    2. agent 目前使用的git repo 

2. HBS 會定期去詢問 `plugin git repo address` ，去抓取最新的 `git commit hash`
3. 當 HBS 送給 Agent 的資料，含有 `GitUpdate = true` 時，Agent 會去更新 `plugin` 的版本。
4. 當 HBS 送給 Agent 的資料，含有 `GitRepoUpdate = true` 時，Agent 會去更新 `plugin git repo address`
 