### PR TITLE
[OWL-637][agent] change iface prefix matching code segment

### DIFF
--- a/modules/agent/funcs/ifstat.go
+++ b/modules/agent/funcs/ifstat.go
@@ -1,15 +1,25 @@
 package funcs
 
 import (
+	"strings"
+
 	"github.com/Cepave/open-falcon-backend/common/model"
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
 	log "github.com/Sirupsen/logrus"
 	"github.com/toolkits/nux"
-	"strings"
 )
 
 func NetMetrics() []*model.MetricValue {
 	return CoreNetMetrics(g.Config().Collector.IfacePrefix)
+}
+
+func containsCollector(iface string, ifacePrefix []string) bool {
+	for _, prefix := range ifacePrefix {
+		if strings.Contains(iface, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func CoreNetMetrics(ifacePrefix []string) []*model.MetricValue {
@@ -50,7 +60,7 @@ func CoreNetMetrics(ifacePrefix []string) []*model.MetricValue {
 	inTotalBits := int64(0)
 	outTotalBits := int64(0)
 	for _, netIf := range netIfs {
-		if strings.Contains(netIf.Iface, "eth") || strings.Contains(netIf.Iface, "em") || strings.Contains(netIf.Iface, "enp") {
+		if containsCollector(netIf.Iface, ifacePrefix) {
 			inTotalBits += netIf.InBytes * 8
 			outTotalBits += netIf.OutBytes * 8
 		}

--- a/modules/agent/funcs/ifstat_test.go
+++ b/modules/agent/funcs/ifstat_test.go
@@ -1,0 +1,15 @@
+package funcs
+
+import "testing"
+
+func TestContainsCollector(t *testing.T) {
+	// cat /proc/net/dev
+	in := []string{"eth0", "eth1", "docker0", "em0", "bond3"}
+	ifacePrefix := []string{"eth", "em", "bond", "enp"}
+	out := []bool{true, true, false, true, true}
+	for i, val := range in {
+		if out[i] != containsCollector(val, ifacePrefix) {
+			t.Error("unepected result: ", out[i], val)
+		}
+	}
+}


### PR DESCRIPTION
Originally, iface=eth_all only collects eth, em, enp three types of iface interfaces. 
In this modification, iface=eth_all will collect all the interfaces that assigned in the **collector**  in config file. 

For example, in below cases, 
```
 "collector": {
        "ifacePrefix": ["eth", "em", "bond", "enp"]
    },
```
iface=eth_all  will collect eth, em, bond and enp four kinds of interfaces .