### PR TITLE
[OWL-637][agent] change iface prefix matching code segment

### DIFF
--- a/modules/agent/cfg.example.json
+++ b/modules/agent/cfg.example.json
@@ -29,7 +29,8 @@
         "backdoor": false
     },
     "collector": {
-        "ifacePrefix": ["eth", "em", "bond", "enp"]
+        "ifacePrefix": ["eth", "em", "bond", "enp"],
+        "eth_all": ["eth", "em", "enp"]
     },
     "ignore": {
         "cpu.busy": true,

--- a/modules/agent/funcs/checker.go
+++ b/modules/agent/funcs/checker.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+
 	"github.com/toolkits/nux"
 	"github.com/toolkits/sys"
 )
@@ -19,7 +20,7 @@ func CheckCollector() {
 
 	output["kernel  "] = len(KernelMetrics()) > 0
 	output["df.bytes"] = len(DeviceMetrics()) > 0
-	output["net.if  "] = len(CoreNetMetrics([]string{})) > 0
+	output["net.if  "] = len(CoreNetMetrics([]string{}, []string{})) > 0
 	output["loadavg "] = len(LoadAvgMetrics()) > 0
 	output["cpustat "] = procStatErr == nil
 	output["disk.io "] = listDiskErr == nil

--- a/modules/agent/funcs/ifstat.go
+++ b/modules/agent/funcs/ifstat.go
@@ -1,15 +1,25 @@
 package funcs
 
 import (
+	"strings"
+
 	"github.com/Cepave/open-falcon-backend/common/model"
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
 	log "github.com/Sirupsen/logrus"
 	"github.com/toolkits/nux"
-	"strings"
 )
 
 func NetMetrics() []*model.MetricValue {
 	return CoreNetMetrics(g.Config().Collector.IfacePrefix)
+}
+
+func containsCollector(iface string, ifacePrefix []string) bool {
+	for _, prefix := range ifacePrefix {
+		if strings.Contains(iface, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func CoreNetMetrics(ifacePrefix []string) []*model.MetricValue {
@@ -50,7 +60,7 @@ func CoreNetMetrics(ifacePrefix []string) []*model.MetricValue {
 	inTotalBits := int64(0)
 	outTotalBits := int64(0)
 	for _, netIf := range netIfs {
-		if strings.Contains(netIf.Iface, "eth") || strings.Contains(netIf.Iface, "em") || strings.Contains(netIf.Iface, "enp") {
+		if containsCollector(netIf.Iface, ifacePrefix) {
 			inTotalBits += netIf.InBytes * 8
 			outTotalBits += netIf.OutBytes * 8
 		}

--- a/modules/agent/funcs/ifstat.go
+++ b/modules/agent/funcs/ifstat.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NetMetrics() []*model.MetricValue {
-	return CoreNetMetrics(g.Config().Collector.IfacePrefix)
+	return CoreNetMetrics(g.Config().Collector.IfacePrefix, g.Config().Collector.EthAll)
 }
 
 func containsCollector(iface string, ifacePrefix []string) bool {
@@ -22,7 +22,7 @@ func containsCollector(iface string, ifacePrefix []string) bool {
 	return false
 }
 
-func CoreNetMetrics(ifacePrefix []string) []*model.MetricValue {
+func CoreNetMetrics(ifacePrefix []string, ethAllPrefix []string) []*model.MetricValue {
 
 	netIfs, err := nux.NetIfs(ifacePrefix)
 	if err != nil {
@@ -60,7 +60,7 @@ func CoreNetMetrics(ifacePrefix []string) []*model.MetricValue {
 	inTotalBits := int64(0)
 	outTotalBits := int64(0)
 	for _, netIf := range netIfs {
-		if containsCollector(netIf.Iface, ifacePrefix) {
+		if containsCollector(netIf.Iface, ethAllPrefix) {
 			inTotalBits += netIf.InBytes * 8
 			outTotalBits += netIf.OutBytes * 8
 		}

--- a/modules/agent/funcs/ifstat_test.go
+++ b/modules/agent/funcs/ifstat_test.go
@@ -1,0 +1,15 @@
+package funcs
+
+import "testing"
+
+func TestContainsCollector(t *testing.T) {
+	// cat /proc/net/dev
+	in := []string{"eth0", "eth1", "docker0", "em0", "bond3"}
+	ifacePrefix := []string{"eth", "em", "bond", "enp"}
+	out := []bool{true, true, false, true, true}
+	for i, val := range in {
+		if out[i] != containsCollector(val, ifacePrefix) {
+			t.Error("unepected result: ", out[i], val)
+		}
+	}
+}

--- a/modules/agent/funcs/ifstat_test.go
+++ b/modules/agent/funcs/ifstat_test.go
@@ -5,11 +5,22 @@ import "testing"
 func TestContainsCollector(t *testing.T) {
 	// cat /proc/net/dev
 	in := []string{"eth0", "eth1", "docker0", "em0", "bond3"}
-	ifacePrefix := []string{"eth", "em", "bond", "enp"}
+	ethAll := []string{"eth", "em", "bond", "enp"}
 	out := []bool{true, true, false, true, true}
 	for i, val := range in {
-		if out[i] != containsCollector(val, ifacePrefix) {
+		if out[i] != containsCollector(val, ethAll) {
 			t.Error("unepected result: ", out[i], val)
+		}
+	}
+}
+
+func TestCoreNetMetrics(t *testing.T) {
+	ifacePrefix := []string{"eth", "lo", "bond", "em", "br"}
+	ethAll := []string{"eth", "lo"}
+	t.Log("Test eth_all: ", ethAll)
+	for _, val := range CoreNetMetrics(ifacePrefix, ethAll) {
+		if val.Metric == "net.if.in.bits" || val.Metric == "net.if.out.bits" {
+			t.Log(val)
 		}
 	}
 }

--- a/modules/agent/g/cfg.go
+++ b/modules/agent/g/cfg.go
@@ -2,10 +2,11 @@ package g
 
 import (
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
 	"os"
 	"strings"
 	"sync"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/toolkits/file"
 )
@@ -39,6 +40,7 @@ type HttpConfig struct {
 
 type CollectorConfig struct {
 	IfacePrefix []string `json:"ifacePrefix"`
+	EthAll      []string `json:"eth_all"`
 }
 
 type GlobalConfig struct {


### PR DESCRIPTION
Originally, **iface=eth_all** only collects **eth, em, enp**  iface interfaces. 
In this modification, **iface=eth_all** will collect all the interfaces that assigned in the **collector.eth_all**  in config file. 

For example, in below cases, 
```
"collector": {
        "ifacePrefix": ["eth", "em", "bond", "enp", "p2p2"] ,
        "eth_all": ["eth", "em", "enp", "p2p2"]
    },
```
**iface=eth_all**  will collect **eth, em, enp, p2p2**  interfaces .