### PR TITLE
[OWL-897][agent] reserve data dir under plugin dir.

### DIFF
--- a/modules/agent/cron/plugin.go
+++ b/modules/agent/cron/plugin.go
@@ -29,6 +29,16 @@ func SyncMinePlugins() {
 	go syncMinePlugins()
 }
 
+func dirFilter(userBindDir []string) (resultDir []string) {
+	// remove reserved dir: data
+	for _, val := range userBindDir {
+		if !strings.HasPrefix(val, "data/") && val != "data" {
+			resultDir = append(resultDir, val)
+		}
+	}
+	return
+}
+
 func syncMinePlugins() {
 
 	var (
@@ -61,7 +71,7 @@ func syncMinePlugins() {
 			continue
 		}
 
-		pluginDirs = resp.Plugins
+		pluginDirs = dirFilter(resp.Plugins)
 		timestamp = resp.Timestamp
 		plugins.GitRepo = resp.GitRepo
 
@@ -77,6 +87,7 @@ func syncMinePlugins() {
 
 		if g.Config().Debug {
 			log.Println(&resp)
+			log.Println(pluginDirs)
 		}
 
 		if len(pluginDirs) == 0 {


### PR DESCRIPTION
當 agent 從 HBS 收到哪些的 dir 要視為「現在要執行的 plugin dir 」時，對這些 dir 做過濾(filtering)。去除下列兩種字串

 1.  ”data”
 2.  含有 "data/" prefix 
