### PR TITLE
[OWL-867][hbs][common] add necessary debug message for verification

### DIFF
--- a/common/model/agent.go
+++ b/common/model/agent.go
@@ -14,11 +14,12 @@ type AgentReportRequest struct {
 
 func (this *AgentReportRequest) String() string {
 	return fmt.Sprintf(
-		"<Hostname:%s, IP:%s, AgentVersion:%s, PluginVersion:%s>",
+		"<Hostname:%s, IP:%s, AgentVersion:%s, PluginVersion:%s, GitRepo: %s>",
 		this.Hostname,
 		this.IP,
 		this.AgentVersion,
 		this.PluginVersion,
+		this.GitRepo,
 	)
 }
 

--- a/modules/hbs/rpc/agent.go
+++ b/modules/hbs/rpc/agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Cepave/open-falcon-backend/common/utils"
 	"github.com/Cepave/open-falcon-backend/modules/hbs/cache"
 	"github.com/Cepave/open-falcon-backend/modules/hbs/g"
+	log "github.com/Sirupsen/logrus"
 )
 
 func (t *Agent) MinePlugins(args model.AgentHeartbeatRequest, reply *model.AgentPluginsResponse) error {
@@ -22,6 +23,7 @@ func (t *Agent) MinePlugins(args model.AgentHeartbeatRequest, reply *model.Agent
 	reply.GitRepo = g.Config().GitRepo
 	reply.GitUpdate = cache.GitUpdateCheck(args.Hostname)
 	reply.GitRepoUpdate = cache.GitRepoUpdateCheck(args.Hostname)
+	log.Debugln("show reply of MinePlugins: ", reply)
 
 	return nil
 }
@@ -32,6 +34,7 @@ func (t *Agent) ReportStatus(args *model.AgentReportRequest, reply *model.Simple
 		return nil
 	}
 
+	log.Debugln("show request of ReportStatus: ", args)
 	cache.Agents.Put(args)
 
 	return nil


### PR DESCRIPTION
OWL-867 modify HBS and Agent modules at the same time. Considering DevOps issues, new HBS will be first updated, then we updated all the 5000 Agents. To make sure that new version of HBS can cooperate with old version of Agent. We add some more Debug log into HBS and common.  