### PR TITLE
[OWL-693][OWL-964][agent] Hotfix of bug: agent automatically updating plugin dir will halt

### DIFF
--- a/modules/agent/control
+++ b/modules/agent/control
@@ -41,7 +41,6 @@ function start() {
     if [ $running -gt 0 ];then
         echo $! > $pidfile
         echo "$app started..., pid=$!"
-        sleep 5 && curl 127.0.0.1:1988/plugin/update
         return 0
     else
         echo "$app failed to start."

--- a/modules/agent/cron/reporter.go
+++ b/modules/agent/cron/reporter.go
@@ -22,11 +22,16 @@ func reportAgentStatus(interval time.Duration) {
 			hostname = fmt.Sprintf("error:%s", err.Error())
 		}
 
+		currPluginVersion, currPluginErr := g.GetCurrPluginVersion()
+		if currPluginErr != nil {
+			log.Println("GetCurrPluginVersion returns error: ", currPluginErr)
+		}
+
 		req := model.AgentReportRequest{
 			Hostname:      hostname,
 			IP:            g.IP(),
 			AgentVersion:  g.VERSION,
-			PluginVersion: g.GetCurrPluginVersion(),
+			PluginVersion: currPluginVersion,
 			GitRepo:       g.GetCurrGitRepo(),
 		}
 

--- a/modules/agent/g/tool.go
+++ b/modules/agent/g/tool.go
@@ -2,6 +2,7 @@ package g
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -9,14 +10,18 @@ import (
 	"github.com/toolkits/file"
 )
 
-func GetCurrPluginVersion() string {
+func GetCurrPluginVersion() (str string, err error) {
 	if !Config().Plugin.Enabled {
-		return "plugin not enabled"
+		str = "0"
+		err = errors.New("plugin not enabled")
+		return
 	}
 
 	pluginDir := Config().Plugin.Dir
 	if !file.IsExist(pluginDir) {
-		return "plugin dir not existent"
+		str = "0"
+		err = errors.New("plugin dir not existent")
+		return
 	}
 
 	cmd := exec.Command("git", "rev-parse", "HEAD")
@@ -24,12 +29,15 @@ func GetCurrPluginVersion() string {
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
-		return fmt.Sprintf("Error:%s", err.Error())
+		str = "0"
+		return
 	}
 
-	return strings.TrimSpace(out.String())
+	// err is nil
+	str = strings.TrimSpace(out.String())
+	return
 }
 
 func GetCurrGitRepo() string {


### PR DESCRIPTION
Agent automatically updating plugin directory halts because of RPC **Agent.ReportStatus** fail.

Open-falcon original GetCurrPluginVersion() is somewhat badly written. Refactor it in this commit. 

