### PR TITLE
[OWL-975][agent] add command timout to prevent goroutine blocking

### DIFF
--- a/modules/agent/http/plugin.go
+++ b/modules/agent/http/plugin.go
@@ -1,16 +1,38 @@
 package http
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
 	"github.com/Cepave/open-falcon-backend/modules/agent/plugins"
+	log "github.com/Sirupsen/logrus"
 	"github.com/toolkits/file"
 )
+
+func RunCmdWithTimeout(cmd *exec.Cmd, timeout int64) (err error) {
+	if err = cmd.Start(); err != nil {
+		log.Fatalln("Start shell command error:", err)
+	}
+	done := make(chan error)
+	go func() { done <- cmd.Wait() }()
+
+	d := time.Duration(time.Duration(timeout) * time.Second)
+	select {
+	case err = <-done:
+	case <-time.After(d):
+		// timed out
+		cmd.Process.Kill()
+		errMsg := fmt.Sprintf("Command %s time out", cmd.Path)
+		err = errors.New(errMsg)
+	}
+	return
+}
 
 func DeleteAndCloneRepo(pluginDir string, gitRemoteAddr string) (out string) {
 	parentDir := file.Dir(pluginDir)
@@ -29,7 +51,7 @@ func DeleteAndCloneRepo(pluginDir string, gitRemoteAddr string) (out string) {
 	}
 	cmd := exec.Command("git", "clone", gitRemoteAddr, file.Basename(pluginDir))
 	cmd.Dir = parentDir
-	err2 := cmd.Run()
+	err2 := RunCmdWithTimeout(cmd, 600)
 	if err2 != nil {
 		out = out + fmt.Sprintf("\ngit clone in dir:%s fail. error: %s", parentDir, err2)
 		return
@@ -53,7 +75,7 @@ func configPluginRoutes() {
 			// git pull
 			cmd := exec.Command("git", "pull")
 			cmd.Dir = dir
-			err := cmd.Run()
+			err := RunCmdWithTimeout(cmd, 600)
 			if err != nil {
 				w.Write([]byte(fmt.Sprintf("git pull in dir:%s fail. error: %s", dir, err)))
 				w.Write([]byte(DeleteAndCloneRepo(dir, plugins.GitRepo)))
@@ -63,7 +85,7 @@ func configPluginRoutes() {
 			// git clone
 			cmd := exec.Command("git", "clone", plugins.GitRepo, file.Basename(dir))
 			cmd.Dir = parentDir
-			err := cmd.Run()
+			err := RunCmdWithTimeout(cmd, 600)
 			if err != nil {
 				w.Write([]byte(fmt.Sprintf("git clone in dir:%s fail. error: %s", parentDir, err)))
 				return

--- a/modules/agent/http/plugin.go
+++ b/modules/agent/http/plugin.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -28,8 +27,7 @@ func RunCmdWithTimeout(cmd *exec.Cmd, timeout int64) (err error) {
 	case <-time.After(d):
 		// timed out
 		cmd.Process.Kill()
-		errMsg := fmt.Sprintf("Command %s time out", cmd.Path)
-		err = errors.New(errMsg)
+		err = fmt.Errorf("Command %s time out", cmd.Path)
 	}
 	return
 }

--- a/modules/agent/http/plugin_test.go
+++ b/modules/agent/http/plugin_test.go
@@ -1,10 +1,22 @@
 package http
 
-import "testing"
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
 
 func TestDeleteAndCloneRepo(t *testing.T) {
-	out := deleteAndCloneRepo("./plugin", "https://github.com/humorless/openfalcon-plugin.git")
+	out := DeleteAndCloneRepo("./plugin", "https://github.com/humorless/openfalcon-plugin.git")
 	t.Log("test deleteAndCloneRepo: ", out)
-	out = deleteAndCloneRepo("/", "https://github.com/humorless/openfalcon-plugin.git")
+	out = DeleteAndCloneRepo("/", "https://github.com/humorless/openfalcon-plugin.git")
 	t.Log("test deleteAndCloneRepo: ", out)
+}
+
+func TestRunCmdWithTimeout(t *testing.T) {
+	cmd := exec.Command("sleep", "500")
+	t1 := time.Now()
+	RunCmdWithTimeout(cmd, 3)
+	t2 := time.Now()
+	t.Log("Time spent should less than 4 second: ", t2.Sub(t1))
 }


### PR DESCRIPTION
1 add a function  RunCmdWithTimeout to prevent "git clone" and "git pull" block the go routine. 
2 add a unit test to test RunCmdWithTimeout.