### PR TITLE
[OWL-975][agent] fix go routines leak problem and log.fatal problem.

### DIFF
--- a/modules/agent/http/plugin_test.go
+++ b/modules/agent/http/plugin_test.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/toolkits/sys"
 )
 
 func TestDeleteAndCloneRepo(t *testing.T) {
@@ -16,7 +18,23 @@ func TestDeleteAndCloneRepo(t *testing.T) {
 func TestRunCmdWithTimeout(t *testing.T) {
 	cmd := exec.Command("sleep", "500")
 	t1 := time.Now()
-	RunCmdWithTimeout(cmd, 3)
+	cmd.Start()
+	err, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(3)*time.Second)
 	t2 := time.Now()
 	t.Log("Time spent should less than 4 second: ", t2.Sub(t1))
+	t.Log("error message is:", err)
+	t.Log("Timeout happens: ", isTimeout)
+	time.Sleep(3 * time.Second)
+	if err != nil || isTimeout != true {
+		t.Error("failed in sys.CmdRunWithTimeout")
+	}
+
+	cmd2 := exec.Command("sleep", "1")
+	cmd2.Start()
+	err2, isTimeout2 := sys.CmdRunWithTimeout(cmd, time.Duration(3)*time.Second)
+	t.Log("error message is:", err2)
+	t.Log("Timeout happens: ", isTimeout2)
+	if isTimeout2 != false {
+		t.Error("failed in sys.CmdRunWithTimeout")
+	}
 }


### PR DESCRIPTION
Fix two primary problems: 

1. goroutine leak problem
2. log.fatal problem

Originally in OWL-975, the previous version of `func RunCmdWithTimeout` suffers from goroutine leaking problem when timeout happens. Use the `sys.CmdRunWithTimeout` provided by open-falcon author instead. 
Ref:
https://github.com/golang/go/wiki/Timeouts

In Golang, log.fatal will call os.exit(1) after print out error messages. This kind of log behavior is out of my expectation. 
http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html#log_fatal_exit