### PR TITLE
[OWL-1011][agent][common][transfer][nqm-agent] fix goroutine leaks.

### DIFF
--- a/common/pool/pool.go
+++ b/common/pool/pool.go
@@ -65,7 +65,7 @@ func (this *SafeRpcConnPools) Call(addr, method string, args interface{}, resp i
 	rpcClient := conn.(RpcClient)
 	callTimeout := time.Duration(this.CallTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()

--- a/modules/agent/g/rpc.go
+++ b/modules/agent/g/rpc.go
@@ -61,7 +61,7 @@ func (this *SingleConnRpcClient) Call(method string, args interface{}, reply int
 	this.insureConn()
 
 	timeout := time.Duration(50 * time.Second)
-	done := make(chan error)
+	done := make(chan error, 1)
 
 	go func() {
 		err := this.rpcClient.Call(method, args, reply)

--- a/modules/nqm-agent/rpc.go
+++ b/modules/nqm-agent/rpc.go
@@ -66,7 +66,7 @@ func RPCCall(method string, args interface{}, reply interface{}) error {
 		initConn(rpcServer, rpcTimeout)
 	}
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, reply)
 	}()

--- a/modules/transfer/sender/conn_pool/conn_pool_manager.go
+++ b/modules/transfer/sender/conn_pool/conn_pool_manager.go
@@ -83,7 +83,7 @@ func (this *SafeRpcConnPools) Call(addr, method string, args interface{}, resp i
 	rpcClient := conn.(RpcClient)
 	callTimeout := time.Duration(this.CallTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()
@@ -216,7 +216,7 @@ func (this *TsdbConnPoolHelper) Send(data []byte) (err error) {
 
 	cli := conn.(TsdbClient).cli
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		_, err = cli.Write(data)
 		done <- err

--- a/modules/transfer/sender/conn_pool/influxdb_conn_pool_manager.go
+++ b/modules/transfer/sender/conn_pool/influxdb_conn_pool_manager.go
@@ -133,7 +133,7 @@ func (this *InfluxdbConnPools) Call(addr string, items []*cmodel.JudgeItem) erro
 	influxdbClient := conn.(InfluxdbClient)
 	callTimeout := time.Duration(this.CallTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- influxdbClient.Call(items)
 	}()

--- a/modules/transfer/sender/conn_pool/nqmrpc_conn_pool_manager.go
+++ b/modules/transfer/sender/conn_pool/nqmrpc_conn_pool_manager.go
@@ -79,7 +79,7 @@ func (this *NqmRpcConnPoolHelper) Call(method string, args interface{}, resp int
 
 	rpcClient := conn.(JsonRpcV2Client)
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()

--- a/modules/transfer/sender/conn_pool/staging_conn_pool_manager.go
+++ b/modules/transfer/sender/conn_pool/staging_conn_pool_manager.go
@@ -58,7 +58,7 @@ func (this *StagingConnPoolHelper) Call(method string, args interface{}, resp in
 	rpcClient := conn.(RpcClient)
 	callTimeout := time.Duration(this.callTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()


### PR DESCRIPTION
fix goroutine leaks problem when timeout really happens.
Ref https://github.com/golang/go/wiki/Timeouts  

Using channel to implement timeout, channel should have a buffer size of one. Otherwise, the goroutine that has the send channel would never be destroyed when timeout really happens.