### PR TITLE
[OWL-1008] [fe] Improve alerts reponse time, by set events info as optional data set

### DIFF
--- a/modules/fe/Portal_APIDoc.md
+++ b/modules/fe/Portal_APIDoc.md
@@ -327,6 +327,10 @@
 ### `GET` `POST` /api/v2/portal/eventcases/get
 * `required login session`
 * params:
+  * `includeEvents` string (boolean)
+    * ex. false, true
+    * default: `false`
+    * if true will response events information (time-series alerts data by step).
   * `startTime` timestamp [if set then can't skip endTime]
     * ex: 1457450919
     * if not specific, means get all

--- a/modules/fe/http/portal/onTimeUpdate_controller.go
+++ b/modules/fe/http/portal/onTimeUpdate_controller.go
@@ -89,7 +89,7 @@ func CronForQuery(updatTo chan UpdatedEvents, pid chan string) {
 		currentTime := time.Now().Unix()
 		startTime := (currentTime - int64(60*1))
 		log.Debugf("cron job for on time query: range -> %v ~ %v", startTime, currentTime)
-		events, err := event.GetEventCases(startTime, currentTime, -1, "ALL", "ALL", 500, 0, "root", "ALL", "")
+		events, err := event.GetEventCases(false, startTime, currentTime, -1, "ALL", "ALL", 500, 0, "root", "ALL", "")
 		if err != nil {
 			log.Errorf("crond get evnetCase go err: %v", err.Error())
 		}

--- a/modules/fe/http/portal/portal_controller.go
+++ b/modules/fe/http/portal/portal_controller.go
@@ -65,11 +65,12 @@ func (this *PortalController) GetEventCasesV2() {
 	}
 	alerts, endpoints, err := event.AlertsConvert(events)
 	alerts2 := event.GetAlertInfo(alerts, endpoints, showAll)
+	alerts3 := event.GetAlertsNotes(alerts2)
 	if err != nil {
 		this.ResposeError(baseResp, err.Error())
 		return
 	}
-	baseResp.Data["eventCases"] = alerts2
+	baseResp.Data["eventCases"] = alerts3
 	this.ServeApiJson(baseResp)
 	return
 }

--- a/modules/fe/http/portal/portal_controller.go
+++ b/modules/fe/http/portal/portal_controller.go
@@ -27,7 +27,8 @@ func (this *PortalController) GetEventCases() {
 	limitNum, _ := this.GetInt("limit", 0)
 	elimit, _ := this.GetInt("elimit", 0)
 	caseId := this.GetString("caseId", "")
-	events, err := event.GetEventCases(startTime, endTime, prioprity, status, processStatus, limitNum, elimit, username, metrics, caseId)
+	includeEvents, _ := this.GetBool("includeEvents", false)
+	events, err := event.GetEventCases(includeEvents, startTime, endTime, prioprity, status, processStatus, limitNum, elimit, username, metrics, caseId)
 	if err != nil {
 		this.ResposeError(baseResp, err.Error())
 		return
@@ -56,7 +57,8 @@ func (this *PortalController) GetEventCasesV2() {
 	elimit, _ := this.GetInt("elimit", 0)
 	caseId := this.GetString("caseId", "")
 	showAll, _ := this.GetBool("show_all", false)
-	events, err := event.GetEventCases(startTime, endTime, prioprity, status, processStatus, limitNum, elimit, username, metrics, caseId)
+	includeEvents, _ := this.GetBool("includeEvents", false)
+	events, err := event.GetEventCases(includeEvents, startTime, endTime, prioprity, status, processStatus, limitNum, elimit, username, metrics, caseId)
 	if err != nil {
 		this.ResposeError(baseResp, err.Error())
 		return

--- a/modules/fe/http/portal/portal_controller.go
+++ b/modules/fe/http/portal/portal_controller.go
@@ -63,14 +63,14 @@ func (this *PortalController) GetEventCasesV2() {
 		this.ResposeError(baseResp, err.Error())
 		return
 	}
-	alerts, endpoints, err := event.AlertsConvert(events)
-	alerts2 := event.GetAlertInfo(alerts, endpoints, showAll)
-	alerts3 := event.GetAlertsNotes(alerts2)
+	alertTmpStore, endpoints, err := event.AlertsConvert(events)
+	alertswithInfo := event.GetAlertInfo(alertTmpStore, endpoints, showAll)
+	alertswithNote := event.GetAlertsNotes(alertswithInfo)
 	if err != nil {
 		this.ResposeError(baseResp, err.Error())
 		return
 	}
-	baseResp.Data["eventCases"] = alerts3
+	baseResp.Data["eventCases"] = alertswithNote
 	this.ServeApiJson(baseResp)
 	return
 }

--- a/modules/fe/model/falcon_portal/alerts.go
+++ b/modules/fe/model/falcon_portal/alerts.go
@@ -33,7 +33,8 @@ func AlertsConvert(result []EventCases) (resp []AlertsResp, endpointSet *hashset
 		recordOne.TimeStart = sTime
 		recordOne.TimeUpdate = eTime
 		recordOne.Duration = getDuration(eTime)
-		recordOne.Notes = getNote(item.Id, sTime)
+		// recordOne.Notes = getNote(item.Id, sTime)
+		recordOne.Notes = []map[string]string{}
 		recordOne.Events = item.Events
 		recordOne.Process = item.ProcessStatus
 		recordOne.Function = item.Func
@@ -125,5 +126,14 @@ func GetAlertInfo(resp []AlertsResp, endpointList *hashset.Set, showAll bool) (r
 		respCompleteTmp = append(respCompleteTmp, item)
 	}
 	respComplete = respCompleteTmp
+	return
+}
+
+func GetAlertsNotes(alerts []AlertsResp) (alertsResp []AlertsResp) {
+	alertsResp = []AlertsResp{}
+	for _, record := range alerts {
+		record.Notes = getNote(record.Hash, record.TimeStart)
+		alertsResp = append(alertsResp, record)
+	}
 	return
 }

--- a/modules/fe/model/falcon_portal/event_query_action.go
+++ b/modules/fe/model/falcon_portal/event_query_action.go
@@ -34,7 +34,7 @@ func genSqlFilterTemplete(whereConditions []string) string {
 
 const SkipFilter = "ALL"
 
-func GetEventCases(startTime int64, endTime int64, priority int, status string, progressStatus string, limit int, elimit int, username string, metrics string, caseId string) (result []EventCases, err error) {
+func GetEventCases(includeEvents bool, startTime int64, endTime int64, priority int, status string, progressStatus string, limit int, elimit int, username string, metrics string, caseId string) (result []EventCases, err error) {
 	config := g.Config()
 	q := orm.NewOrm()
 	q.Using("falcon_portal")
@@ -78,20 +78,22 @@ func GetEventCases(startTime int64, endTime int64, priority int, status string, 
 		result = []EventCases{}
 		return
 	}
-	//set default number of event
-	var eventLimit int
-	if eventLimit = elimit; elimit == 0 {
-		eventLimit = 10
-	}
-	for indx, event := range result {
-		var eventArr []*Events
-		q.Raw(fmt.Sprintf("SELECT * FROM `events` WHERE event_caseId = '%s' order by timestamp DESC Limit %d", event.Id, eventLimit)).QueryRows(&eventArr)
-		if len(eventArr) != 0 {
-			event.Events = eventArr
-		} else {
-			event.Events = []*Events{}
+	if includeEvents {
+		//set default number of event
+		var eventLimit int
+		if eventLimit = elimit; elimit == 0 {
+			eventLimit = 10
 		}
-		result[indx] = event
+		for indx, event := range result {
+			var eventArr []*Events
+			q.Raw(fmt.Sprintf("SELECT * FROM `events` WHERE event_caseId = '%s' order by timestamp DESC Limit %d", event.Id, eventLimit)).QueryRows(&eventArr)
+			if len(eventArr) != 0 {
+				event.Events = eventArr
+			} else {
+				event.Events = []*Events{}
+			}
+			result[indx] = event
+		}
 	}
 	return
 }

--- a/modules/fe/model/falcon_portal/event_query_action.go
+++ b/modules/fe/model/falcon_portal/event_query_action.go
@@ -159,7 +159,7 @@ func GetNotes(eventCaseId string, limit int, startTime int64, endTime int64, fil
 	//allow api only set the startTime and use the currentTime as the endTime
 	case startTime != 0 && endTime == 0:
 		endTime = time.Now().Unix()
-	case startTime == 0 && endTime == 0:
+	case startTime != 0 && endTime != 0:
 		tempTime := ""
 		q.Raw("SELECT timestamp FROM event_cases WHERE id = ?", eventCaseId).QueryRow(&tempTime)
 		if tempTime != "" {


### PR DESCRIPTION
1. currently the latest alarms page of owl-light is not required, set this by optional response data set to improve response time.
2. fix a logic error of EventNotes api, but current no any front-end use this api, no this not affect ours owl-light, this error is found by my test script.
3. move getNotes action after boss api filter action, this can reduce sql computing time