### PR TITLE
[OWL-988][transfer] 關閉 transfer 的 config/reload API

### DIFF
--- a/modules/transfer/http/common.go
+++ b/modules/transfer/http/common.go
@@ -2,10 +2,10 @@ package http
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/Cepave/open-falcon-backend/modules/transfer/g"
 	"github.com/toolkits/file"
-	"net/http"
-	"strings"
 )
 
 func configCommonRoutes() {
@@ -26,11 +26,6 @@ func configCommonRoutes() {
 	})
 
 	http.HandleFunc("/config/reload", func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.RemoteAddr, "127.0.0.1") {
-			g.ParseConfig(g.ConfigFile)
-			RenderDataJson(w, "ok")
-		} else {
-			RenderDataJson(w, "no privilege")
-		}
+		RenderDataJson(w, "/config/reload is not suppored in transfer now. Please use restart instead.")
 	})
 }

--- a/modules/transfer/http/proc_http.go
+++ b/modules/transfer/http/proc_http.go
@@ -1,12 +1,13 @@
 package http
 
 import (
-	"github.com/Cepave/open-falcon-backend/modules/transfer/proc"
-	"github.com/Cepave/open-falcon-backend/modules/transfer/sender"
-	cutils "github.com/open-falcon/common/utils"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/Cepave/open-falcon-backend/modules/transfer/proc"
+	"github.com/Cepave/open-falcon-backend/modules/transfer/sender"
+	cutils "github.com/open-falcon/common/utils"
 )
 
 func configProcHttpRoutes() {
@@ -31,20 +32,25 @@ func configProcHttpRoutes() {
 		args := strings.Split(urlParam, "/")
 
 		argsLen := len(args)
-		endpoint := args[0]
-		metric := args[1]
-		tags := make(map[string]string)
-		if argsLen > 2 {
-			tagVals := strings.Split(args[2], ",")
-			for _, tag := range tagVals {
-				tagPairs := strings.Split(tag, "=")
-				if len(tagPairs) == 2 {
-					tags[tagPairs[0]] = tagPairs[1]
+		if argsLen >= 2 {
+			endpoint := args[0]
+			metric := args[1]
+			tags := make(map[string]string)
+			if argsLen > 2 {
+				tagVals := strings.Split(args[2], ",")
+				for _, tag := range tagVals {
+					tagPairs := strings.Split(tag, "=")
+					if len(tagPairs) == 2 {
+						tags[tagPairs[0]] = tagPairs[1]
+					}
 				}
 			}
+			proc.RecvDataTrace.SetPK(cutils.PK(endpoint, metric, tags))
+			RenderDataJson(w, proc.RecvDataTrace.GetAllTraced())
+		} else {
+			msg := "API trace needs to have endpoint, metric, parameter"
+			RenderDataJson(w, msg)
 		}
-		proc.RecvDataTrace.SetPK(cutils.PK(endpoint, metric, tags))
-		RenderDataJson(w, proc.RecvDataTrace.GetAllTraced())
 	})
 
 	// filter


### PR DESCRIPTION
原始的 transfer API `config/reload` 就沒有考慮許多複雜的情況。
現在因為在某些情況，會發生 panic ，先將這個 API 關閉。
目前可以用 restart 做為替代方案