### PR TITLE
[OWL-937][agent] Add a new builtin metric "agent.alive.30sec"

### DIFF
--- a/modules/agent/funcs/agent.go
+++ b/modules/agent/funcs/agent.go
@@ -7,3 +7,7 @@ import (
 func AgentMetrics() []*model.MetricValue {
 	return []*model.MetricValue{GaugeValue("agent.alive", 1)}
 }
+
+func AgentMetricsThirty() []*model.MetricValue {
+	return []*model.MetricValue{GaugeValue("agent.alive.30", 1)}
+}

--- a/modules/agent/funcs/agent.go
+++ b/modules/agent/funcs/agent.go
@@ -9,5 +9,5 @@ func AgentMetrics() []*model.MetricValue {
 }
 
 func AgentMetricsThirty() []*model.MetricValue {
-	return []*model.MetricValue{GaugeValue("agent.alive.30", 1)}
+	return []*model.MetricValue{GaugeValue("agent.alive.30sec", 1)}
 }

--- a/modules/agent/funcs/funcs.go
+++ b/modules/agent/funcs/funcs.go
@@ -10,11 +10,21 @@ type FuncsAndInterval struct {
 	Interval int
 }
 
+const (
+	IntervalThirtySec = 30
+)
+
 var Mappers []FuncsAndInterval
 
 func BuildMappers() {
 	interval := g.Config().Transfer.Interval
 	Mappers = []FuncsAndInterval{
+		FuncsAndInterval{
+			Fs: []func() []*model.MetricValue{
+				AgentMetricsThirty,
+			},
+			Interval: IntervalThirtySec,
+		},
 		FuncsAndInterval{
 			Fs: []func() []*model.MetricValue{
 				AgentMetrics,

--- a/modules/nodata/collector/collector_cron.go
+++ b/modules/nodata/collector/collector_cron.go
@@ -25,7 +25,7 @@ var (
 )
 
 func StartCollectorCron() {
-	collectorCron.AddFuncCC("*/20 * * * * ?", func() {
+	collectorCron.AddFuncCC("*/10 * * * * ?", func() {
 		start := time.Now().Unix()
 		cnt := collectDataOnce()
 		end := time.Now().Unix()

--- a/modules/nodata/judge/judge_cron.go
+++ b/modules/nodata/judge/judge_cron.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	judgeCron     = tcron.New()
-	judgeCronSpec = "0 * * * * ?"
+	judgeCronSpec = "0/20 * * * * ?"
 )
 
 func StartJudgeCron() {
@@ -95,8 +95,8 @@ func genTs(nowTs int64, step int64) int64 {
 }
 
 func getTimeout(step int64) int64 {
-	if step < 60 {
-		return 180 //60*3
+	if step < 30 {
+		return 90 //30*3
 	}
 
 	return step * 3

--- a/modules/nodata/judge/judge_cron.go
+++ b/modules/nodata/judge/judge_cron.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	judgeCron     = tcron.New()
-	judgeCronSpec = "0/20 * * * * ?"
+	judgeCronSpec = "*/20 * * * * ?"
 )
 
 func StartJudgeCron() {


### PR DESCRIPTION
## Modification

 1. In order to make the `agent.alive` builtin metric more sensible, especially add a new builtin metric `agent.alive.30sec`.  This builtin metric `agent.alive.30sec` can be used with `nodata` to detect whether `agent` is alive. 

 2. In `nodata`, the collect, judge, send cycle has been changed to minimum 30 seconds so as to collaborate with `agent.alive.30sec`

 3. In `nodata`, the minimum timeout changes from 180 seconds to 90 seconds. 

## How to use this new feature

  1. Setup a template rule to detect `agent.alive.30sec`. For example, `all(#6) < 1`
  2. Setup `nodata` to trace `agent.alive.30sec`. For example, ` metric: agent.alive.30sec, type: GAUGE, step: 30, value: -1`

