### PR TITLE
[OWL-1016][alarm][fe] Set default beego logger to monochrome output.

### DIFF
--- a/modules/alarm/http/http.go
+++ b/modules/alarm/http/http.go
@@ -53,6 +53,7 @@ func Duration(now, before int64) string {
 
 func init() {
 	configRoutes()
+	beego.SetLogger("console", `{"color":false}`)
 	beego.AddFuncMap("duration", Duration)
 }
 

--- a/modules/fe/http/http.go
+++ b/modules/fe/http/http.go
@@ -42,6 +42,7 @@ func Start() {
 	portal.ConfigRoutes()
 	boss.ConfigRoutes()
 
+	beego.SetLogger("console", `{"color":false}`)
 	beego.AddFuncMap("member", uic_model.MembersByTeamId)
 	beego.InsertFilter("*", beego.BeforeRouter, cors.Allow(&cors.Options{
 		AllowAllOrigins: true,


### PR DESCRIPTION
Set default beego logger to monochrome output.
There are still color codes with debug(DEV) mode due to the lack of option in beego.