### PR TITLE
[OWL-1018][backend] Fix `all`, `trash` & `clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TARGET_SOURCE = $(shell find main.go g cmd -name '*.go')
 CMD = aggregator graph hbs judge nodata query sender task transfer fe alarm agent
 TARGET = open-falcon
 
-VERSION?=$(shell awk -F\" '/^const Version/ { print $$2; exit }' ./g/version.go)
+VERSION := $(shell cat VERSION)
 
 trash:
 	trash -k -cache package_cache_tmp
@@ -15,7 +15,7 @@ $(CMD):
 	go build -o bin/$@/falcon-$@ ./modules/$@
 
 $(TARGET): $(TARGET_SOURCE)
-	go build -ldflags "-X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(< VERSION)" -o open-falcon
+	go build -ldflags "-X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(VERSION)" -o open-falcon
 
 # dev creates binaries for testing locally - these are put into ./bin and $GOPATH
 dev: format

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,7 @@ TARGET = open-falcon
 
 VERSION := $(shell cat VERSION)
 
-trash:
-	trash -k -cache package_cache_tmp
-all:
-	$(trash)
-	$(CMD) $(TARGET)
+all: trash $(CMD) $(TARGET)
 
 $(CMD):
 	go build -o bin/$@/falcon-$@ ./modules/$@
@@ -53,6 +49,10 @@ clean:
 	@rm -rf ./out
 	@rm -rf ./$(TARGET)
 	@rm -rf ./package_cache_tmp
+	@rm -rf ./vendor
 	@rm -rf open-falcon-v$(VERSION).tar.gz
+
+trash:
+	trash -k -cache package_cache_tmp
 
 .PHONY: trash clean all aggregator graph hbs judge nodata query sender task transfer fe


### PR DESCRIPTION
In the original `Makefile`, the `make all` failed due to the incorrect code. Also, the `rm -rf ./vendor` wasn't added in `make clean`.