### PR TITLE
[OWL-998][backend] Fix the flags of subcommands

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,11 +12,12 @@ var versionFlag bool
 
 var RootCmd = &cobra.Command{
 	Use: "open-falcon",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(c *cobra.Command, args []string) error {
 		if versionFlag {
 			fmt.Printf("Open-Falcon version %s, build %s\n", Version, GitCommit)
-			os.Exit(0)
+			return nil
 		}
+		return c.Usage()
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -6,13 +6,18 @@ import (
 
 	"github.com/Cepave/open-falcon-backend/cmd"
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 )
 
 var versionFlag bool
 
 var RootCmd = &cobra.Command{
 	Use: "open-falcon",
+	Run: func(cmd *cobra.Command, args []string) {
+		if versionFlag {
+			fmt.Printf("Open-Falcon version %s, build %s\n", Version, GitCommit)
+			os.Exit(0)
+		}
+	},
 }
 
 func init() {
@@ -22,17 +27,13 @@ func init() {
 	RootCmd.AddCommand(cmd.Check)
 	RootCmd.AddCommand(cmd.Monitor)
 	RootCmd.AddCommand(cmd.Reload)
+
+	RootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "show version")
 	cmd.Start.Flags().BoolVar(&cmd.PreqOrderFlag, "preq-order", false, "start modules in the order of prerequisites")
 	cmd.Start.Flags().BoolVar(&cmd.ConsoleOutputFlag, "console-output", false, "print the module's output to the console")
-	flag.BoolVarP(&versionFlag, "version", "v", false, "show version")
-	flag.Parse()
 }
 
 func main() {
-	if versionFlag {
-		fmt.Printf("Open-Falcon version %s, build %s\n", Version, GitCommit)
-		os.Exit(0)
-	}
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Now the flags of `--console-output` & `--preq-order` of `start` command works properly.