### PR TITLE
[OWL-1018][backend] Use `configure` for setting the building environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET = open-falcon
 
 VERSION := $(shell cat VERSION)
 
-all: trash $(CMD) $(TARGET)
+all: $(CMD) $(TARGET)
 
 $(CMD):
 	go build -o bin/$@/falcon-$@ ./modules/$@
@@ -52,7 +52,4 @@ clean:
 	@rm -rf ./vendor
 	@rm -rf open-falcon-v$(VERSION).tar.gz
 
-trash:
-	trash -k -cache package_cache_tmp
-
-.PHONY: trash clean all aggregator graph hbs judge nodata query sender task transfer fe
+.PHONY: clean all aggregator graph hbs judge nodata query sender task transfer fe

--- a/configure
+++ b/configure
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+command -v trash >/dev/null 2>&1  || {
+  echo "trash not found";
+  echo "Installing trash...";
+  go get github.com/rancher/trash
+  if [[ $? != 0 ]]; then exit $?; fi
+  echo "Successfully installed trash";
+}
+
+echo "Running trash...";
+trash -k -cache package_cache_tmp;
+if [[ $? != 0 ]]; then exit $?; fi
+
+echo "Fetching dependencies...";
+go get ./...;
+if [[ $? != 0 ]]; then exit $?; fi


### PR DESCRIPTION
In this PR, the I move `trash` from `Makefile` to `configure`, which runs `go get ./...` too 