### PR TITLE
[OWL-865][nqm-agent][transfer] Support of `name tag` and `group tag`

### DIFF
--- a/modules/nqm-agent/marshal.go
+++ b/modules/nqm-agent/marshal.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Cepave/open-falcon-backend/common/model"
@@ -32,11 +33,12 @@ func (p ParamToAgent) String() string {
 }
 
 type nqmNodeData struct {
-	Id         string
-	IspId      string
-	ProvinceId string
-	CityId     string
-	NameTagId  string
+	Id          string
+	IspId       string
+	ProvinceId  string
+	CityId      string
+	NameTagId   string
+	GroupTagIds string
 }
 
 func marshalJSONParamsToCassandra(nqmDataGram string, metric string) ParamToAgent {
@@ -65,31 +67,43 @@ func assembleTags(target nqmNodeData, agent nqmNodeData, dataMap map[string]stri
 		",agent-province-id=" + agent.ProvinceId +
 		",agent-city-id=" + agent.CityId +
 		",agent-name-tag-id=" + agent.NameTagId +
+		",agent-group-tag-ids=" + agent.GroupTagIds +
 		",target-id=" + target.Id +
 		",target-isp-id=" + target.IspId +
 		",target-province-id=" + target.ProvinceId +
 		",target-city-id=" + target.CityId +
 		",target-name-tag-id=" + target.NameTagId +
+		",target-group-tag-ids=" + target.GroupTagIds +
 		convToKeyValueString(dataMap)
+}
+
+func convIntSlcToStr(args []int32) string {
+	strSlc := []string{}
+	for _, arg := range args {
+		strSlc = append(strSlc, strconv.Itoa(int(arg)))
+	}
+	return strings.Join(strSlc, "-")
 }
 
 func convToNqmAgent(s model.NqmAgent) nqmNodeData {
 	return nqmNodeData{
-		Id:         strconv.Itoa(s.Id),
-		IspId:      strconv.Itoa(int(s.IspId)),
-		ProvinceId: strconv.Itoa(int(s.ProvinceId)),
-		CityId:     strconv.Itoa(int(s.CityId)),
-		NameTagId:  strconv.Itoa(-1),
+		Id:          strconv.Itoa(s.Id),
+		IspId:       strconv.Itoa(int(s.IspId)),
+		ProvinceId:  strconv.Itoa(int(s.ProvinceId)),
+		CityId:      strconv.Itoa(int(s.CityId)),
+		NameTagId:   strconv.Itoa(int(s.NameTagId)),
+		GroupTagIds: convIntSlcToStr(s.GroupTagIds),
 	}
 }
 
 func convToNqmTarget(s model.NqmTarget) nqmNodeData {
 	return nqmNodeData{
-		Id:         strconv.Itoa(s.Id),
-		IspId:      strconv.Itoa(int(s.IspId)),
-		ProvinceId: strconv.Itoa(int(s.ProvinceId)),
-		CityId:     strconv.Itoa(int(s.CityId)),
-		NameTagId:  strconv.Itoa(-1),
+		Id:          strconv.Itoa(s.Id),
+		IspId:       strconv.Itoa(int(s.IspId)),
+		ProvinceId:  strconv.Itoa(int(s.ProvinceId)),
+		CityId:      strconv.Itoa(int(s.CityId)),
+		NameTagId:   strconv.Itoa(int(s.NameTagId)),
+		GroupTagIds: convIntSlcToStr(s.GroupTagIds),
 	}
 }
 

--- a/modules/nqm-agent/marshal_test.go
+++ b/modules/nqm-agent/marshal_test.go
@@ -39,32 +39,39 @@ func TestConvToKeyValueString(t *testing.T) {
 }
 
 func TestAssembleTags(t *testing.T) {
-	agent := nqmNodeData{
-		"-1", "-1", "-1", "-1", "11", "12-13-14",
+	agent := []nqmNodeData{
+		{"-1", "-1", "-1", "-1", "11", "12-13-14"},
+		{"-1", "-1", "-1", "-1", "-1", ""},
+		{"-1", "-1", "-1", "-1", "11", "12-13-14"},
+		{"-1", "-1", "-1", "-1", "-1", ""},
 	}
 	target := nqmNodeData{
 		"-2", "-2", "-2", "-2", "21", "22-23-24",
 	}
 	tests := []map[string]string{
 		{"rttmax": "46.5", "rttavg": "14.5", "rttmdev": "-1", "rttmedian": "-1", "pkttransmit": "100", "pktreceive": "100", "rttmin": "8.61"},
+		{"rttmax": "46.5", "rttavg": "14.5", "rttmdev": "-1", "rttmedian": "-1", "pkttransmit": "100", "pktreceive": "100", "rttmin": "8.61"},
+		{"time": "13.6"},
 		{"time": "13.6"},
 	}
 
 	expecteds := []string{
 		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=11,agent-group-tag-ids=12-13-14,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=21,target-group-tag-ids=22-23-24,rttmin=8.61,rttmax=46.5,rttavg=14.5,rttmdev=-1,rttmedian=-1,pkttransmit=100,pktreceive=100,time=",
+		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=-1,agent-group-tag-ids=,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=21,target-group-tag-ids=22-23-24,rttmin=8.61,rttmax=46.5,rttavg=14.5,rttmdev=-1,rttmedian=-1,pkttransmit=100,pktreceive=100,time=",
 		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=11,agent-group-tag-ids=12-13-14,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=21,target-group-tag-ids=22-23-24,rttmin=,rttmax=,rttavg=,rttmdev=,rttmedian=,pkttransmit=,pktreceive=,time=13.6",
+		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=-1,agent-group-tag-ids=,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=21,target-group-tag-ids=22-23-24,rttmin=,rttmax=,rttavg=,rttmdev=,rttmedian=,pkttransmit=,pktreceive=,time=13.6",
 	}
 
 	//t_out := nqmTagsAssembler(target, agent, tests)
 	for i, v := range tests {
-		kv := assembleTags(target, agent, v)
+		kv := assembleTags(target, agent[i], v)
 		strs := strings.Split(kv, ",")
 		for _, str := range strs {
 			if !strings.Contains(expecteds[i], str) {
-				t.Error(expecteds[i], str)
+				t.Error("case:", i, expecteds[i], str)
 			}
 		}
-		t.Log(assembleTags(target, agent, v))
+		t.Log(assembleTags(target, agent[i], v))
 	}
 }
 

--- a/modules/nqm-agent/marshal_test.go
+++ b/modules/nqm-agent/marshal_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -39,10 +40,10 @@ func TestConvToKeyValueString(t *testing.T) {
 
 func TestAssembleTags(t *testing.T) {
 	agent := nqmNodeData{
-		"-1", "-1", "-1", "-1", "-1",
+		"-1", "-1", "-1", "-1", "11", "12-13-14",
 	}
 	target := nqmNodeData{
-		"-2", "-2", "-2", "-2", "-2",
+		"-2", "-2", "-2", "-2", "21", "22-23-24",
 	}
 	tests := []map[string]string{
 		{"rttmax": "46.5", "rttavg": "14.5", "rttmdev": "-1", "rttmedian": "-1", "pkttransmit": "100", "pktreceive": "100", "rttmin": "8.61"},
@@ -50,8 +51,8 @@ func TestAssembleTags(t *testing.T) {
 	}
 
 	expecteds := []string{
-		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=-1,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=-2,rttmin=8.61,rttmax=46.5,rttavg=14.5,rttmdev=-1,rttmedian=-1,pkttransmit=100,pktreceive=100,time=",
-		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=-1,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=-2,rttmin=,rttmax=,rttavg=,rttmdev=,rttmedian=,pkttransmit=,pktreceive=,time=13.6",
+		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=11,agent-group-tag-ids=12-13-14,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=21,target-group-tag-ids=22-23-24,rttmin=8.61,rttmax=46.5,rttavg=14.5,rttmdev=-1,rttmedian=-1,pkttransmit=100,pktreceive=100,time=",
+		"agent-id=-1,agent-isp-id=-1,agent-province-id=-1,agent-city-id=-1,agent-name-tag-id=11,agent-group-tag-ids=12-13-14,target-id=-2,target-isp-id=-2,target-province-id=-2,target-city-id=-2,target-name-tag-id=21,target-group-tag-ids=22-23-24,rttmin=,rttmax=,rttavg=,rttmdev=,rttmedian=,pkttransmit=,pktreceive=,time=13.6",
 	}
 
 	//t_out := nqmTagsAssembler(target, agent, tests)
@@ -68,7 +69,6 @@ func TestAssembleTags(t *testing.T) {
 }
 
 func TestMarshalStatsRow(t *testing.T) {
-	// Hostname is the config dependency which lies in func MarshalIntoParameters
 	var cfg GeneralConfig
 	generalConfig = &cfg
 	cfg.Hostname = "unit-test-hostname"
@@ -92,10 +92,10 @@ func TestMarshalStatsRow(t *testing.T) {
 	GetGeneralConfig().hbsResp.Store(resp)
 
 	agent := nqmNodeData{
-		"-1", "-1", "-1", "-1", "-1",
+		"-1", "-1", "-1", "-1", "11", "12-13-14",
 	}
 	target := nqmNodeData{
-		"-2", "-2", "-2", "-2", "-1",
+		"-2", "-2", "-2", "-2", "21", "22-23-24",
 	}
 
 	// fping, 4 JSON parameters, only test the 4th which is for Cassandra
@@ -138,5 +138,22 @@ func TestMarshalStatsRow(t *testing.T) {
 			t.Error(expecteds[i][1], params[1])
 		}
 		t.Log(expecteds[i][1], params[1])
+	}
+}
+
+func TestConvIntSlcToStr(t *testing.T) {
+	tests := []struct {
+		input    []int32
+		expected string
+	}{
+		{[]int32{1, 2, 3, 4, 5}, string("1-2-3-4-5")},
+	}
+	for i, v := range tests {
+		actual := convIntSlcToStr(v.input)
+		expected := v.expected
+		t.Logf("Check case %d: %s(actual) == %s(expected)", i, actual, expected)
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Error on case %d: %s(actual) != %s(expected)", i, actual, expected)
+		}
 	}
 }

--- a/modules/nqm-agent/task_test.go
+++ b/modules/nqm-agent/task_test.go
@@ -68,12 +68,13 @@ func initJsonRpcServer(addr string) {
 }
 
 func initJsonRpcClient(srvAddr string) {
-	rpcClient.RpcServer = srvAddr
+	rpcServer = srvAddr
 	req = model.NqmTaskRequest{
 		Hostname:     "nqm-agent",
 		IpAddress:    "1.2.3.4",
 		ConnectionId: "arg-arg-arg",
 	}
+	rpcClient = initConn(rpcServer, rpcTimeout)
 }
 
 func TestTask(t *testing.T) {

--- a/modules/nqm-agent/version.go
+++ b/modules/nqm-agent/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.9.3"
+const VERSION = "0.9.4"

--- a/modules/transfer/sender/queue_item.go
+++ b/modules/transfer/sender/queue_item.go
@@ -5,11 +5,12 @@ import (
 )
 
 type nqmEndpoint struct {
-	Id         int32 `json:"id"`
-	IspId      int16 `json:"isp_id"`
-	ProvinceId int16 `json:"province_id"`
-	CityId     int16 `json:"city_id"`
-	NameTagId  int32 `json:"name_tag_id"`
+	Id          int32   `json:"id"`
+	IspId       int16   `json:"isp_id"`
+	ProvinceId  int16   `json:"province_id"`
+	CityId      int16   `json:"city_id"`
+	NameTagId   int32   `json:"name_tag_id"`
+	GroupTagIds []int32 `json:"group_tag_ids"`
 }
 
 func (end nqmEndpoint) String() string {

--- a/modules/transfer/sender/sender.go
+++ b/modules/transfer/sender/sender.go
@@ -329,6 +329,23 @@ func strToInt32(out *int32, index string, dict map[string]string) error {
 	return nil
 }
 
+func strToInt32Slc(out *[]int32, index string, dict map[string]string) error {
+	if v, ok := dict[index]; ok {
+		if v == "" {
+			return nil
+		}
+		strSlc := strings.Split(v, "-")
+		for _, str := range strSlc {
+			i, err := strconv.Atoi(str)
+			if err != nil {
+				return err
+			}
+			*out = append(*out, int32(i))
+		}
+	}
+	return nil
+}
+
 func strToInt16(out *int16, index string, dict map[string]string) error {
 	var err error
 	var ii int64
@@ -344,11 +361,12 @@ func strToInt16(out *int16, index string, dict map[string]string) error {
 
 func convert2NqmEndpoint(d *cmodel.MetaData, endType string) (*nqmEndpoint, error) {
 	t := nqmEndpoint{
-		Id:         -1,
-		IspId:      -1,
-		ProvinceId: -1,
-		CityId:     -1,
-		NameTagId:  -1,
+		Id:          -1,
+		IspId:       -1,
+		ProvinceId:  -1,
+		CityId:      -1,
+		NameTagId:   -1,
+		GroupTagIds: []int32{},
 	}
 
 	if err := strToInt32(&t.Id, endType+"-id", d.Tags); err != nil {
@@ -364,6 +382,9 @@ func convert2NqmEndpoint(d *cmodel.MetaData, endType string) (*nqmEndpoint, erro
 		return nil, err
 	}
 	if err := strToInt32(&t.NameTagId, endType+"-name-tag-id", d.Tags); err != nil {
+		return nil, err
+	}
+	if err := strToInt32Slc(&t.GroupTagIds, endType+"-group-tag-ids", d.Tags); err != nil {
 		return nil, err
 	}
 

--- a/modules/transfer/sender/sender_test.go
+++ b/modules/transfer/sender/sender_test.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"encoding/json"
 	cmodel "github.com/open-falcon/common/model"
+	"reflect"
 	"testing"
 )
 
@@ -54,24 +55,26 @@ func createMetaData() *cmodel.MetaData {
 		Value:       0.000000,
 		CounterType: "",
 		Tags: map[string]string{
-			"rttmin":             "18.64",
-			"rttavg":             "21",
-			"rttmax":             "26.56",
-			"rttmdev":            "234.2",
-			"rttmedian":          "21.5",
-			"pkttransmit":        "13",
-			"pktreceive":         "12",
-			"dstpoint":           "test.endpoint.niean.2",
-			"agent-id":           "1334",
-			"agent-isp-id":       "12",
-			"agent-province-id":  "13",
-			"agent-city-id":      "14",
-			"agent-name-tag-id":  "123",
-			"target-id":          "2334",
-			"target-isp-id":      "22",
-			"target-province-id": "23",
-			"target-city-id":     "24",
-			"target-name-tag-id": "223",
+			"rttmin":               "18.64",
+			"rttavg":               "21",
+			"rttmax":               "26.56",
+			"rttmdev":              "234.2",
+			"rttmedian":            "21.5",
+			"pkttransmit":          "13",
+			"pktreceive":           "12",
+			"dstpoint":             "test.endpoint.niean.2",
+			"agent-id":             "1334",
+			"agent-isp-id":         "12",
+			"agent-province-id":    "13",
+			"agent-city-id":        "14",
+			"agent-name-tag-id":    "123",
+			"agent-group-tag-ids":  "12-13-14",
+			"target-id":            "2334",
+			"target-isp-id":        "22",
+			"target-province-id":   "23",
+			"target-city-id":       "24",
+			"target-name-tag-id":   "223",
+			"target-group-tag-ids": "22-23-24",
 		},
 	}
 
@@ -107,14 +110,15 @@ func TestConvert2NqmEndpoint(t *testing.T) {
 	in := createMetaData()
 	out_ptr, _ := convert2NqmEndpoint(in, "agent")
 	out := nqmEndpoint{
-		Id:         1334,
-		IspId:      12,
-		ProvinceId: 13,
-		CityId:     14,
-		NameTagId:  123,
+		Id:          1334,
+		IspId:       12,
+		ProvinceId:  13,
+		CityId:      14,
+		NameTagId:   123,
+		GroupTagIds: []int32{12, 13, 14},
 	}
 
-	if out != *out_ptr {
+	if !reflect.DeepEqual(out, *out_ptr) {
 		t.Error("Expected output: ", out)
 		t.Error("Real output:     ", *out_ptr)
 
@@ -122,14 +126,15 @@ func TestConvert2NqmEndpoint(t *testing.T) {
 
 	out_ptr, _ = convert2NqmEndpoint(in, "target")
 	out = nqmEndpoint{
-		Id:         2334,
-		IspId:      22,
-		ProvinceId: 23,
-		CityId:     24,
-		NameTagId:  223,
+		Id:          2334,
+		IspId:       22,
+		ProvinceId:  23,
+		CityId:      24,
+		NameTagId:   223,
+		GroupTagIds: []int32{22, 23, 24},
 	}
 
-	if out != *out_ptr {
+	if !reflect.DeepEqual(out, *out_ptr) {
 		t.Error("Expected output: ", out)
 		t.Error("Real output:     ", *out_ptr)
 	}

--- a/modules/transfer/test/debug
+++ b/modules/transfer/test/debug
@@ -44,7 +44,7 @@ function conn_pool_status(){
 
 ## trace
 function trace_recv(){
-    e="test.endpoint.niean.1" 
+    e="test.endpoint.niean.1"
     m="test.metric.niean.1"
     t="tag0=tag0-niean-1,tag1=tag1-niean-1,tag2=tag2-niean-1"
     curl -s "$httpprex/trace/$e/$m/$t" | python -m json.tool
@@ -52,7 +52,7 @@ function trace_recv(){
 
 ## filter
 function filter_recv(){
-    e="test.endpoint.niean.1" 
+    e="test.endpoint.niean.1"
     m="test.metric.niean.1"
     opt="lt"
     val="5"
@@ -62,7 +62,7 @@ function filter_recv(){
 
 ## api
 function http_post(){
-    e="test.endpoint.niean.1" 
+    e="test.endpoint.niean.1"
     m="test.metric.niean.1"
     t="tag0=tag0-niean-1,tag1=tag1-niean-1,tag2=tag2-niean-1"
     ts=`date +%s`
@@ -71,9 +71,9 @@ function http_post(){
 }
 
 function nqm(){
-    e="test.endpoint.niean.2"
+    e="test.endpoint.chyeh.1"
     m="nqm-fping"
-    t="rttmin=18.64, rttavg=21.5, rttmax=26.9, rttmdev=4.7, pkttransmit=13, pktreceive=11, agent-id=1334, agent-isp-id=12, agent-province-id=13, agent-city-id=14, agent-name-tag-id=123, target-id=2334, target-isp-id=22, target-province-id=23, target-city-id=24, target-name-tag-id=223"
+    t="rttmin=18.64, rttavg=21.5, rttmax=26.9, rttmdev=4.7, pkttransmit=13, pktreceive=11, agent-id=1334, agent-isp-id=12, agent-province-id=13, agent-city-id=14, agent-name-tag-id=123, agent-group-tag-id=145-167-189-101, target-id=2334, target-isp-id=22, target-province-id=23, target-city-id=24, target-name-tag-id=223, target-group-tag-id=245-267-289-201"
     ts=`date +%s`
     val=`expr $ts / 60 % 10`
     curl -s -X POST -d "[{\"metric\":\"$m\", \"endpoint\":\"$e\", \"timestamp\":$ts,\"step\":60, \"value\":$val, \"counterType\":\"GAUGE\",\"tags\":\"$t\"}]" "$httpprex/api/push" | python -m json.tool
@@ -81,12 +81,12 @@ function nqm(){
 
 
 function nqm_copy(){
-    e="test.endpoint.niean.2"
+    e="test.endpoint.chyeh.1"
     m="nqm-fping"
     ts=`date +%s`
     val=`expr $ts / 60 % 10`
     rand=$RANDOM
-    t="rttmin=18.64, rttavg=21.5, rttmax=26.9, rttmdev=4.7, pkttransmit=13, pktreceive=11, agent-id=1334$rand, agent-isp-id=12, agent-province-id=13, agent-city-id=14, agent-name-tag-id=123, target-id=6969, target-isp-id=22, target-province-id=23, target-city-id=24, target-name-tag-id=223"
+    t="rttmin=18.64, rttavg=21.5, rttmax=26.9, rttmdev=4.7, pkttransmit=13, pktreceive=11, agent-id=1334$rand, agent-isp-id=12, agent-province-id=13, agent-city-id=14, agent-name-tag-id=123, agent-group-tag-id=145-167-189-101, target-id=6969, target-isp-id=22, target-province-id=23, target-city-id=24, target-name-tag-id=223, target-group-tag-id=245-267-289-201"
     curl -s -X POST -d "[{\"metric\":\"$m\", \"endpoint\":\"$e\", \"timestamp\":$ts,\"step\":60, \"value\":$val, \"counterType\":\"GAUGE\",\"tags\":\"$t\"}]" "$httpprex/api/push" | python -m json.tool
 }
 
@@ -99,14 +99,14 @@ function nqmbatch(){
     done
 }
 
-## telnet 
+## telnet
 function telnet_send(){
     cnt=$1
     if [ "X$cnt" == "X" ];then
         cnt=1
     fi
 
-    e="test.endpoint.niean.1" 
+    e="test.endpoint.niean.1"
     m="test.metric.niean.1"
     type="GAUGE"
     step=60
@@ -151,7 +151,7 @@ function build_mockagent(){
 }
 
 function clean_mockagent(){
-    rm -rf $builddir  
+    rm -rf $builddir
     ec=$?
     [ $ec -eq 0 ] && echo -e "clean mockagent, ok" || { echo -e "clean mockagent, error"; exit $ec; }
 }
@@ -163,7 +163,7 @@ function kill_mockagent(){
         kill -9  $pid &>/dev/null
         echo -e "kill mockagent, $pid"
         sleep 0.01
-    done 
+    done
     echo -e "kill mockagent ok"
 }
 
@@ -172,7 +172,7 @@ function start_mockagent(){
     if [ "X$cnt" == "X" ];then
         cnt=1
     fi
-    
+
     for i in `seq 1 $cnt`
     do
         id=malog.`date +%s`
@@ -203,16 +203,16 @@ case $action in
         tail_log
         ;;
     "trace")
-        trace_recv 
+        trace_recv
         ;;
     "filter")
-        filter_recv 
+        filter_recv
         ;;
     "conn")
         conn_pool_status $2
         ;;
     "post")
-        http_post 
+        http_post
         ;;
     "nqm")
         nqm
@@ -230,13 +230,12 @@ case $action in
         kill_mockagent
         ;;
     "cleanm")
-        clean_mockagent 
+        clean_mockagent
         ;;
     "buildm")
         build_mockagent
         ;;
     *)
-        statistics 
+        statistics
         ;;
 esac
-


### PR DESCRIPTION
In this PR, I made changes at `nqm-agent` and `transfer` so that these two modules support the feature of classify NQM agents and targets by `name_tag_id` and `group_tag_ids`.