### PR TITLE
[OWL-900][transfer] Specify `nqm-fping` exactly

### DIFF
--- a/modules/nqm-agent/task_test.go
+++ b/modules/nqm-agent/task_test.go
@@ -68,12 +68,13 @@ func initJsonRpcServer(addr string) {
 }
 
 func initJsonRpcClient(srvAddr string) {
-	rpcClient.RpcServer = srvAddr
+	rpcServer = srvAddr
 	req = model.NqmTaskRequest{
 		Hostname:     "nqm-agent",
 		IpAddress:    "1.2.3.4",
 		ConnectionId: "arg-arg-arg",
 	}
+	rpcClient = initConn(rpcServer, rpcTimeout)
 }
 
 func TestTask(t *testing.T) {

--- a/modules/transfer/sender/sender.go
+++ b/modules/transfer/sender/sender.go
@@ -3,7 +3,6 @@ package sender
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -268,10 +267,13 @@ func Demultiplex(items []*cmodel.MetaData) ([]*cmodel.MetaData, []*cmodel.MetaDa
 	generics := []*cmodel.MetaData{}
 
 	for _, item := range items {
-		if strings.HasPrefix(item.Metric, "nqm-") {
-			nqms = append(nqms, item)
-		} else {
+		switch item.Metric {
+		default:
 			generics = append(generics, item)
+		case "nqm-fping":
+			nqms = append(nqms, item)
+		case "nqm-tcpping":
+		case "nqm-tcpconn":
 		}
 	}
 

--- a/modules/transfer/sender/sender_test.go
+++ b/modules/transfer/sender/sender_test.go
@@ -15,7 +15,7 @@ func TestDemultiplex(t *testing.T) {
 	for i := 0; i < size; i++ {
 		if i%3 == 0 {
 			fv := &cmodel.MetaData{
-				Metric: "nqm-metrics",
+				Metric: "nqm-fping",
 				Step:   int64(i),
 			}
 			caseIn = append(caseIn, fv)
@@ -48,7 +48,7 @@ func TestDemultiplex(t *testing.T) {
 
 func createMetaData() *cmodel.MetaData {
 	in := cmodel.MetaData{
-		Metric:      "nqm-metrics",
+		Metric:      "nqm-fping",
 		Timestamp:   1460366463,
 		Step:        60,
 		Value:       0.000000,


### PR DESCRIPTION
This PR is a temporary workaround, which only allows the metric of `nqm-fping` to be sent to Cassandra DB. Before `nqm-tcpping` and `nqm-tcpconn` is supported, it should work this way.