### PR TITLE
[OWL-1103][nqm-agent] Fix the problem that `nqm-agent` crashes after restarting `hbs` 

### DIFF
--- a/modules/nqm-agent/query.go
+++ b/modules/nqm-agent/query.go
@@ -47,7 +47,7 @@ func query() {
 	var resp model.NqmTaskResponse
 	err := RPCCall("NqmAgent.Task", req, &resp)
 	if err != nil {
-		log.Println("[ hbs ] Error on RPC call:", err)
+		log.Errorln("[ hbs ] Error on RPC call:", err)
 		return
 	}
 	log.Println("[ hbs ] Response received")

--- a/modules/nqm-agent/task_test.go
+++ b/modules/nqm-agent/task_test.go
@@ -68,12 +68,13 @@ func initJsonRpcServer(addr string) {
 }
 
 func initJsonRpcClient(srvAddr string) {
-	rpcClient.RpcServer = srvAddr
+	rpcServer = srvAddr
 	req = model.NqmTaskRequest{
 		Hostname:     "nqm-agent",
 		IpAddress:    "1.2.3.4",
 		ConnectionId: "arg-arg-arg",
 	}
+	rpcClient = initConn(rpcServer, rpcTimeout)
 }
 
 func TestTask(t *testing.T) {

--- a/modules/nqm-agent/task_test.go
+++ b/modules/nqm-agent/task_test.go
@@ -74,7 +74,6 @@ func initJsonRpcClient(srvAddr string) {
 		IpAddress:    "1.2.3.4",
 		ConnectionId: "arg-arg-arg",
 	}
-	rpcClient = initConn(rpcServer, rpcTimeout)
 }
 
 func TestTask(t *testing.T) {

--- a/modules/nqm-agent/version.go
+++ b/modules/nqm-agent/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.9.3"
+const VERSION = "0.9.5"

--- a/modules/transfer/sender/sender.go
+++ b/modules/transfer/sender/sender.go
@@ -3,7 +3,6 @@ package sender
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -268,10 +267,13 @@ func Demultiplex(items []*cmodel.MetaData) ([]*cmodel.MetaData, []*cmodel.MetaDa
 	generics := []*cmodel.MetaData{}
 
 	for _, item := range items {
-		if strings.HasPrefix(item.Metric, "nqm-") {
-			nqms = append(nqms, item)
-		} else {
+		switch item.Metric {
+		default:
 			generics = append(generics, item)
+		case "nqm-fping":
+			nqms = append(nqms, item)
+		case "nqm-tcpping":
+		case "nqm-tcpconn":
 		}
 	}
 

--- a/modules/transfer/sender/sender_test.go
+++ b/modules/transfer/sender/sender_test.go
@@ -15,7 +15,7 @@ func TestDemultiplex(t *testing.T) {
 	for i := 0; i < size; i++ {
 		if i%3 == 0 {
 			fv := &cmodel.MetaData{
-				Metric: "nqm-metrics",
+				Metric: "nqm-fping",
 				Step:   int64(i),
 			}
 			caseIn = append(caseIn, fv)
@@ -48,7 +48,7 @@ func TestDemultiplex(t *testing.T) {
 
 func createMetaData() *cmodel.MetaData {
 	in := cmodel.MetaData{
-		Metric:      "nqm-metrics",
+		Metric:      "nqm-fping",
 		Timestamp:   1460366463,
 		Step:        60,
 		Value:       0.000000,


### PR DESCRIPTION
In this PR, I changed how `RPCCall` works. Previously `nqm-agent` establishes a connection to `hbs` as a global variable and it checks if this variable is valid before every single RPC call. I changed this mechanism. Now it sets up a connection before a call and tears it down after that.