### PR TITLE
[OWL-677][nqm-agent] Redesign the mechanism of initialization

### DIFF
--- a/modules/nqm-agent/main.go
+++ b/modules/nqm-agent/main.go
@@ -18,9 +18,10 @@ func main() {
 	}
 
 	vipercfg.Load()
-	InitJSONConfig()
-	InitGeneralConfig()
+	InitConfig()
 	logruslog.Init()
+
+	GenMeta()
 	InitRPC()
 
 	go Query()

--- a/modules/nqm-agent/main.go
+++ b/modules/nqm-agent/main.go
@@ -18,7 +18,8 @@ func main() {
 	}
 
 	vipercfg.Load()
-	InitGeneralConfig(vipercfg.Config().GetString("config"))
+	InitJSONConfig()
+	InitGeneralConfig()
 	logruslog.Init()
 	InitRPC()
 

--- a/modules/nqm-agent/marshal.go
+++ b/modules/nqm-agent/marshal.go
@@ -44,7 +44,7 @@ func marshalJSONParamsToCassandra(nqmDataGram string, metric string) ParamToAgen
 	data.Tags = nqmDataGram
 	data.Metric = metric
 	data.Timestamp = time.Now().Unix()
-	data.Endpoint = GetGeneralConfig().Hostname
+	data.Endpoint = Meta().Hostname
 	data.Value = "0"
 	data.CounterType = "GAUGE"
 	data.Step = int64(60) // a useless field in Cassandra
@@ -99,7 +99,7 @@ func convToNqmTarget(s model.NqmTarget) nqmNodeData {
  *     Transmission Time - float64
  */
 func marshalJSONToGraph(target model.NqmTarget, agent model.NqmAgent, metric string, value interface{}, step int64) ParamToAgent {
-	endpoint := GetGeneralConfig().Hostname
+	endpoint := Meta().Hostname
 	counterType := "GAUGE"
 	tags := "nqm-agent-isp=" + agent.IspName +
 		",nqm-agent-province=" + agent.ProvinceName +

--- a/modules/nqm-agent/push.go
+++ b/modules/nqm-agent/push.go
@@ -14,7 +14,7 @@ func Push(params []ParamToAgent, util string) {
 		log.Fatalln("[", util, "] , Error on formatting body:,", err)
 	}
 
-	postReq, err := http.NewRequest("POST", GetGeneralConfig().Agent.PushURL, bytes.NewBuffer(paramsBody))
+	postReq, err := http.NewRequest("POST", JSONConfig().Agent.PushURL, bytes.NewBuffer(paramsBody))
 	postReq.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	postReq.Header.Set("Connection", "close")
 

--- a/modules/nqm-agent/push.go
+++ b/modules/nqm-agent/push.go
@@ -14,7 +14,7 @@ func Push(params []ParamToAgent, util string) {
 		log.Fatalln("[", util, "] , Error on formatting body:,", err)
 	}
 
-	postReq, err := http.NewRequest("POST", JSONConfig().Agent.PushURL, bytes.NewBuffer(paramsBody))
+	postReq, err := http.NewRequest("POST", Config().Agent.PushURL, bytes.NewBuffer(paramsBody))
 	postReq.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	postReq.Header.Set("Connection", "close")
 

--- a/modules/nqm-agent/query.go
+++ b/modules/nqm-agent/query.go
@@ -11,7 +11,7 @@ import (
 )
 
 func tick() <-chan time.Time {
-	dur := time.Second * GetGeneralConfig().Hbs.Interval
+	dur := time.Second * JSONConfig().Hbs.Interval
 	return time.Tick(dur)
 }
 
@@ -53,7 +53,7 @@ func query() {
 	log.Println("[ hbs ] Response received")
 	HbsRespTime = time.Now()
 
-	oldResp := GetGeneralConfig().hbsResp.Load().(model.NqmTaskResponse)
+	oldResp := HBSResp()
 	if !configFromHbsUpdated(resp, oldResp) {
 		return
 	}
@@ -65,7 +65,7 @@ func query() {
 		msg = msg + " - " + measMsg
 	}
 
-	GetGeneralConfig().hbsResp.Store(resp)
+	SetHBSResp(resp)
 	log.Println(msg)
 }
 

--- a/modules/nqm-agent/query.go
+++ b/modules/nqm-agent/query.go
@@ -11,7 +11,7 @@ import (
 )
 
 func tick() <-chan time.Time {
-	dur := time.Second * JSONConfig().Hbs.Interval
+	dur := time.Second * Config().Hbs.Interval
 	return time.Tick(dur)
 }
 

--- a/modules/nqm-agent/rpc.go
+++ b/modules/nqm-agent/rpc.go
@@ -78,4 +78,5 @@ func InitRPC() {
 		IpAddress:    GetGeneralConfig().IPAddress,
 		ConnectionId: GetGeneralConfig().ConnectionID,
 	}
+	SetHBSResp(model.NqmTaskResponse{})
 }

--- a/modules/nqm-agent/rpc.go
+++ b/modules/nqm-agent/rpc.go
@@ -72,11 +72,11 @@ func RPCCall(method string, args interface{}, reply interface{}) error {
 }
 
 func InitRPC() {
-	rpcServer = JSONConfig().Hbs.RPCServer
+	rpcServer = Config().Hbs.RPCServer
 	req = model.NqmTaskRequest{
-		Hostname:     GetGeneralConfig().Hostname,
-		IpAddress:    GetGeneralConfig().IPAddress,
-		ConnectionId: GetGeneralConfig().ConnectionID,
+		Hostname:     Meta().Hostname,
+		IpAddress:    Meta().IPAddress,
+		ConnectionId: Meta().ConnectionID,
 	}
 	SetHBSResp(model.NqmTaskResponse{})
 }

--- a/modules/nqm-agent/rpc.go
+++ b/modules/nqm-agent/rpc.go
@@ -72,7 +72,7 @@ func RPCCall(method string, args interface{}, reply interface{}) error {
 }
 
 func InitRPC() {
-	rpcServer = GetGeneralConfig().Hbs.RPCServer
+	rpcServer = JSONConfig().Hbs.RPCServer
 	req = model.NqmTaskRequest{
 		Hostname:     GetGeneralConfig().Hostname,
 		IpAddress:    GetGeneralConfig().IPAddress,

--- a/modules/nqm-agent/task.go
+++ b/modules/nqm-agent/task.go
@@ -23,13 +23,13 @@ func Task(u Utility) ([]string, []model.NqmTarget, model.NqmAgent, time.Duration
 	 *     2. NeedPing==ture
 	 *         NqmAgent, NQMTargets, Measurements are not nil
 	 */
-	hbsResp := GetGeneralConfig().hbsResp.Load().(model.NqmTaskResponse)
+	hbsResp := HBSResp()
 
 	if !hbsResp.NeedPing {
-		return nil, nil, model.NqmAgent{}, GetGeneralConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] No tasks assigned.")
+		return nil, nil, model.NqmAgent{}, JSONConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] No tasks assigned.")
 	}
 	if !hbsResp.Measurements[u.UtilName()].Enabled {
-		return nil, nil, model.NqmAgent{}, GetGeneralConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] Not enabled.")
+		return nil, nil, model.NqmAgent{}, JSONConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] Not enabled.")
 
 	}
 	targets := make([]model.NqmTarget, len(hbsResp.Targets))

--- a/modules/nqm-agent/task.go
+++ b/modules/nqm-agent/task.go
@@ -26,10 +26,10 @@ func Task(u Utility) ([]string, []model.NqmTarget, model.NqmAgent, time.Duration
 	hbsResp := HBSResp()
 
 	if !hbsResp.NeedPing {
-		return nil, nil, model.NqmAgent{}, JSONConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] No tasks assigned.")
+		return nil, nil, model.NqmAgent{}, Config().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] No tasks assigned.")
 	}
 	if !hbsResp.Measurements[u.UtilName()].Enabled {
-		return nil, nil, model.NqmAgent{}, JSONConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] Not enabled.")
+		return nil, nil, model.NqmAgent{}, Config().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] Not enabled.")
 
 	}
 	targets := make([]model.NqmTarget, len(hbsResp.Targets))


### PR DESCRIPTION
In this PR, the unmarshalling is done by `viper`, not by the `encode/json`. Some unnecessary functions are removed due to this change. I also refined some code.