### PR TITLE
[OWL-1199][query] fix cronjob of hosts from BOSS API  inside query module

### DIFF
--- a/modules/query/http/cron.go
+++ b/modules/query/http/cron.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/astaxie/beego/orm"
 	"github.com/Cepave/open-falcon-backend/modules/query/g"
-	"github.com/jasonlvhit/gocron"
 	log "github.com/Sirupsen/logrus"
+	"github.com/astaxie/beego/orm"
+	"github.com/jasonlvhit/gocron"
 )
 
 type Contacts struct {
@@ -56,7 +56,7 @@ func SyncHostsAndContactsTable() {
 			intervalToSyncContactsTable := uint64(g.Config().Contacts.Interval)
 			gocron.Every(intervalToSyncContactsTable).Seconds().Do(syncContactsTable)
 		}
-		<- gocron.Start()
+		<-gocron.Start()
 	}
 }
 
@@ -80,7 +80,7 @@ func updateHostsTable(hostnames []string, hostsMap map[string]map[string]string)
 	var hosts []Hosts
 	o := orm.NewOrm()
 	o.Using("boss")
-	_, err := o.QueryTable("hosts").All(&hosts)
+	_, err := o.QueryTable("hosts").Limit(10000).All(&hosts)
 	if err != nil {
 		log.Errorf(err.Error())
 	} else {
@@ -99,6 +99,7 @@ func updateHostsTable(hostnames []string, hostsMap map[string]map[string]string)
 		}
 	}
 
+	hosts = []Hosts{}
 	idcMap := getIDCMap()
 	var host Hosts
 	for _, hostname := range hostnames {
@@ -121,7 +122,7 @@ func updateHostsTable(hostnames []string, hostsMap map[string]map[string]string)
 		hosts = append(hosts, host)
 	}
 	for _, item := range hosts {
-		err := o.QueryTable("hosts").Filter("hostname", item.Hostname).One(&host)
+		err := o.QueryTable("hosts").Limit(10000).Filter("hostname", item.Hostname).One(&host)
 		if err == orm.ErrNoRows {
 			sql := "INSERT INTO boss.hosts("
 			sql += "hostname, exist, activate, platform, idc, ip, "
@@ -292,8 +293,8 @@ func syncHostsTable() {
 		}
 		platformsMap[platformName] = map[string]interface{}{
 			"platformName": platformName,
-			"count": countOfHosts,
-			"contacts": "",
+			"count":        countOfHosts,
+			"contacts":     "",
 		}
 	}
 	sort.Strings(hostnames)

--- a/modules/query/http/grafana_graph_options.go
+++ b/modules/query/http/grafana_graph_options.go
@@ -79,6 +79,7 @@ func getLocation(pop_id int) map[string]string {
 		nodes := map[string]interface{}{}
 		if err := json.Unmarshal(body, &nodes); err != nil {
 			log.Errorf("Response data parsing error: %v", err.Error())
+			return location
 		}
 		status := int(nodes["status"].(float64))
 		if status == 1 {


### PR DESCRIPTION
The data in `hosts` table of `boss` database is not synchronized with BOSS API precisely. 
This error is due to beego ORM module has default `limit` number and some dirty variables. 

This is a temporary quick solution. More suitable solution should proper use SQL syntax like transactions, temp table to replace great quantity of data transferring between memory and database.  
