### PR TITLE
[OWL-1256][agent] fix 'git orphan processes' bug

### DIFF
--- a/modules/agent/http/plugin.go
+++ b/modules/agent/http/plugin.go
@@ -25,6 +25,7 @@ func sessionKill(cmd *exec.Cmd) error {
 // cmdSessionRunWithTimeout runs cmd, and kills the children on timeout
 func cmdSessionRunWithTimeout(cmd *exec.Cmd, timeout time.Duration) (error, bool) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	log.Debugln("show cmd sysProcAttr.Setsid", cmd.SysProcAttr.Setsid)
 	if err := cmd.Start(); err != nil {
 		log.Errorln(cmd.Path, " start fails: ", err)
 		return err, false

--- a/modules/agent/http/plugin.go
+++ b/modules/agent/http/plugin.go
@@ -2,18 +2,46 @@ package http
 
 import (
 	"fmt"
-	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"time"
-
 	"github.com/Cepave/open-falcon-backend/modules/agent/g"
 	"github.com/Cepave/open-falcon-backend/modules/agent/plugins"
 	log "github.com/Sirupsen/logrus"
 	"github.com/toolkits/file"
-	"github.com/toolkits/sys"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
 )
+
+func sessionKill(cmd *exec.Cmd) error {
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		log.Println("failed to kill processes of the same session: ", err)
+		return err
+	}
+	return nil
+}
+
+// cmdSessionRunWithTimeout runs cmd, and kills the children on timeout
+func cmdSessionRunWithTimeout(cmd *exec.Cmd, timeout time.Duration) (error, bool) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		log.Errorln(cmd.Path, " start fails: ", err)
+		return err, false
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-time.After(timeout):
+		log.Printf("timeout, process:%s will be killed", cmd.Path)
+		err := sessionKill(cmd)
+		return err, true
+	case err := <-done:
+		return err, false
+	}
+}
 
 func DeleteAndCloneRepo(pluginDir string, gitRemoteAddr string) (out string) {
 	parentDir := file.Dir(pluginDir)
@@ -35,12 +63,7 @@ func DeleteAndCloneRepo(pluginDir string, gitRemoteAddr string) (out string) {
 
 	cmd := exec.Command("git", "clone", gitRemoteAddr, file.Basename(pluginDir))
 	cmd.Dir = parentDir
-	err := cmd.Start()
-	if err != nil {
-		log.Errorln("git clone start fails: ", err)
-	}
-
-	err2, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(600)*time.Second)
+	err2, isTimeout := cmdSessionRunWithTimeout(cmd, time.Duration(600)*time.Second)
 	if isTimeout {
 		// has be killed
 		if err2 == nil {
@@ -75,11 +98,7 @@ func configPluginRoutes() {
 			// git pull
 			cmd := exec.Command("git", "pull")
 			cmd.Dir = dir
-			err := cmd.Start()
-			if err != nil {
-				log.Errorln("git pull start fails: ", err)
-			}
-			err, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(600)*time.Second)
+			err, isTimeout := cmdSessionRunWithTimeout(cmd, time.Duration(600)*time.Second)
 			if isTimeout {
 				// has be killed
 				if err == nil {
@@ -100,11 +119,7 @@ func configPluginRoutes() {
 			// git clone
 			cmd := exec.Command("git", "clone", plugins.GitRepo, file.Basename(dir))
 			cmd.Dir = parentDir
-			err := cmd.Start()
-			if err != nil {
-				log.Errorln("git clone start fails: ", err)
-			}
-			err, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(600)*time.Second)
+			err, isTimeout := cmdSessionRunWithTimeout(cmd, time.Duration(600)*time.Second)
 			if isTimeout {
 				// has be killed
 				if err == nil {

--- a/modules/agent/http/plugin_test.go
+++ b/modules/agent/http/plugin_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 func TestDeleteAndCloneRepo(t *testing.T) {
@@ -15,6 +17,7 @@ func TestDeleteAndCloneRepo(t *testing.T) {
 }
 
 func TestRunCmdFamilyWithTimeout(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
 	t1 := time.Now()
 	cmd := exec.Command("/bin/sh", "-c", "watch date > date.txt")
 	err, isTimeout := cmdSessionRunWithTimeout(cmd, time.Duration(3)*time.Second)

--- a/modules/agent/http/plugin_test.go
+++ b/modules/agent/http/plugin_test.go
@@ -1,11 +1,10 @@
 package http
 
 import (
+	"github.com/toolkits/sys"
 	"os/exec"
 	"testing"
 	"time"
-
-	"github.com/toolkits/sys"
 )
 
 func TestDeleteAndCloneRepo(t *testing.T) {
@@ -15,32 +14,34 @@ func TestDeleteAndCloneRepo(t *testing.T) {
 	t.Log("test deleteAndCloneRepo: ", out)
 }
 
-func TestRunCmdWithTimeout(t *testing.T) {
-	cmd := exec.Command("sleep", "500")
+func TestRunCmdFamilyWithTimeout(t *testing.T) {
 	t1 := time.Now()
-	err := cmd.Start()
-	if err != nil {
-		t.Log("cmd start fails: ", err)
-	}
-	err, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(3)*time.Second)
+	cmd := exec.Command("/bin/sh", "-c", "watch date > date.txt")
+	err, isTimeout := cmdSessionRunWithTimeout(cmd, time.Duration(3)*time.Second)
 	t2 := time.Now()
 	t.Log("Time spent should less than 4 second: ", t2.Sub(t1))
 	t.Log("error message is:", err)
 	t.Log("Timeout happens: ", isTimeout)
 	time.Sleep(3 * time.Second)
 	if err != nil || isTimeout != true {
-		t.Error("failed in sys.CmdRunWithTimeout")
+		t.Error("failed in cmdSessionRunWithTimeout")
 	}
+	t.Log("verify with: ps aux | head -1;ps aux| grep watch")
+	t.Log("There should not be any 'watch date' existing.")
 
 	cmd2 := exec.Command("sleep", "1")
-	err2 := cmd2.Start()
-	if err2 != nil {
-		t.Log("cmd start fails: ", err2)
-	}
-	err2, isTimeout2 := sys.CmdRunWithTimeout(cmd, time.Duration(3)*time.Second)
+	err2, isTimeout2 := cmdSessionRunWithTimeout(cmd2, time.Duration(3)*time.Second)
 	t.Log("error message is:", err2)
 	t.Log("Timeout happens: ", isTimeout2)
 	if isTimeout2 != false {
-		t.Error("failed in sys.CmdRunWithTimeout")
+		t.Error("failed in cmdSessionRunWithTimeout")
 	}
+
+	cmd3 := exec.Command("/bin/sh", "-c", "watch ls > cmd3.txt")
+	cmd3.Start()
+	err3, isTimeout3 := sys.CmdRunWithTimeout(cmd3, time.Duration(3)*time.Second)
+	t.Log("error message is:", err3)
+	t.Log("Timeout happens: ", isTimeout3)
+	t.Log("verify with: ps aux | head -1;ps aux| grep watch")
+	t.Log("There should be 'watch ls' existing")
 }


### PR DESCRIPTION
`sys.CmdRunWithTimeout` cannot kill all the children processes.
Replace it with `cmdSessionRunWithTimeout`

