### PR TITLE
[OWL-1018][backend] Add `trash` back to `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET = open-falcon
 
 VERSION := $(shell cat VERSION)
 
-all: $(CMD) $(TARGET)
+all: trash $(CMD) $(TARGET)
 
 $(CMD):
 	go build -o bin/$@/falcon-$@ ./modules/$@
@@ -40,4 +40,7 @@ clean:
 	@rm -rf ./vendor
 	@rm -rf open-falcon-v$(VERSION).tar.gz
 
-.PHONY: clean all aggregator graph hbs judge nodata query sender task transfer fe
+trash:
+	trash -k -cache package_cache_tmp
+
+.PHONY: trash clean all aggregator graph hbs judge nodata query sender task transfer fe


### PR DESCRIPTION
f5d27fb was a mistake. In our `docker` environment, we still need `trash` in `Makefile` because we are not using `configure`.