### PR TITLE
[OWL-1243][scripts] modify db schema in boss database

### DIFF
--- a/scripts/mysql/db_schema/boss-db-schema.sql
+++ b/scripts/mysql/db_schema/boss-db-schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE `hosts` (
   `status` varchar(20) CHARACTER SET utf8 DEFAULT NULL,
   `bonding` int(3) UNSIGNED DEFAULT NULL,
   `speed` int(8) UNSIGNED DEFAULT NULL,
-  `remark` varchar(256) CHARACTER SET utf8 DEFAULT NULL,
+  `remark` varchar(512) CHARACTER SET utf8 DEFAULT NULL,
   `updated` datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
@@ -58,6 +58,7 @@ CREATE TABLE `ips` (
   `status` boolean DEFAULT NULL,
   `hostname` varchar(30) CHARACTER SET utf8 NOT NULL,
   `platform` varchar(30) CHARACTER SET utf8 DEFAULT NULL,
+  `type`     varchar(10) CHARACTER SET utf8 DEFAULT NULL,
   `updated` datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
@@ -72,8 +73,10 @@ CREATE TABLE `nodes` (
   `city` varchar(15) CHARACTER SET utf8 NOT NULL,
   `idc` varchar(50) CHARACTER SET utf8 NOT NULL,
   `isp` varchar(15) CHARACTER SET utf8 NOT NULL,
-  `ping` FLOAT DEFAULT NULL,
-  `loss` FLOAT DEFAULT NULL,
+  `send` tinyint(3) UNSIGNED DEFAULT NULL,
+  `receive` tinyint(3) UNSIGNED DEFAULT NULL,
+  `ping` float(6,2) UNSIGNED DEFAULT NULL,
+  `loss` float(6,2) UNSIGNED DEFAULT NULL,
   `updated` datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;

--- a/scripts/mysql/dbpatch/change-log/change-log-boss.yaml
+++ b/scripts/mysql/dbpatch/change-log/change-log-boss.yaml
@@ -13,5 +13,10 @@
         id: "laurence-3",
         filename: "laurence-3.sql",
         comment: "[OWL-1242][scripts] add two columns in  boss.hosts tables"
+    },
+    {
+        id: "laurence-4",
+        filename: "laurence-4.sql",
+        comment: "[OWL-1243][scripts] modify boss.hosts, boss.ips, boss.nodes tables"
     }
 ]

--- a/scripts/mysql/dbpatch/change-log/schema-boss/laurence-4.sql
+++ b/scripts/mysql/dbpatch/change-log/schema-boss/laurence-4.sql
@@ -1,0 +1,16 @@
+TRUNCATE TABLE `ips`;
+TRUNCATE TABLE `hosts`;
+TRUNCATE TABLE `nodes`;
+
+ALTER TABLE `boss`.`ips`
+  ADD COLUMN type varchar(10) NULL AFTER platform;
+
+ALTER TABLE `boss`.`hosts`
+  CHANGE COLUMN remark remark varchar(512) NULL;
+
+ALTER TABLE `boss`.`nodes`
+  CHANGE COLUMN loss loss float(6,2) unsigned NULL AFTER ping,
+  CHANGE COLUMN ping ping float(6,2) unsigned NULL,
+  ADD COLUMN receive tinyint(3) unsigned NULL,
+  ADD COLUMN send tinyint(3) unsigned NULL AFTER isp;
+


### PR DESCRIPTION
Boss API 新增了 `ip_type` 的欄位。要做虛擬 ip 的監控，就必須在 `boss.hosts` 增加對應的欄位 `type`。其它的欄位根據 don 的需求新增。已經用 db_patch 和 mysqldiff 做過驗証。