### PR TITLE
[OWL-865][transfer] Support `GroupTagIds`

### DIFF
--- a/modules/transfer/sender/queue_item.go
+++ b/modules/transfer/sender/queue_item.go
@@ -5,13 +5,12 @@ import (
 )
 
 type nqmEndpoint struct {
-	Id         int32 `json:"id"`
-	IspId      int16 `json:"isp_id"`
-	ProvinceId int16 `json:"province_id"`
-	CityId     int16 `json:"city_id"`
-	NameTagId  int32 `json:"name_tag_id"`
-	//GroupTagIds []int32 `json:"group_tag_ids"`
-	GroupTagIds []int32 `json:"-"`
+	Id          int32   `json:"id"`
+	IspId       int16   `json:"isp_id"`
+	ProvinceId  int16   `json:"province_id"`
+	CityId      int16   `json:"city_id"`
+	NameTagId   int32   `json:"name_tag_id"`
+	GroupTagIds []int32 `json:"group_tag_ids"`
 }
 
 func (end nqmEndpoint) String() string {


### PR DESCRIPTION
The Cassandra API has supported `group_tag_ids`, so the previous workaround can be removed now.