### PR TITLE
[OWL-974] Add a schema for DB migration of Grafana

### DIFF
--- a/scripts/mysql/db_schema/grafana_database-db-schema.sql
+++ b/scripts/mysql/db_schema/grafana_database-db-schema.sql
@@ -1,0 +1,9 @@
+CREATE DATABASE grafana_database;
+USE grafana_database;
+
+CREATE TABLE `session` (
+    `key`       CHAR(16) NOT NULL,
+    `data`      BLOB,
+    `expiry`    INT(11) UNSIGNED NOT NULL,
+    PRIMARY KEY (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
In order to change the default database of Grafana from sqlite3 to MySQL, a new schema is needed.