### PR TITLE
[OWL-1563][hbs] modify how HBS get the lastest commit hash from git repo

### DIFF
--- a/modules/hbs/cache/gitupdate_test.go
+++ b/modules/hbs/cache/gitupdate_test.go
@@ -1,0 +1,12 @@
+package cache
+
+import (
+	"testing"
+)
+
+func TestGitLsRemote(t *testing.T) {
+	hash, _ := gitLsRemote("https://github.com/humorless/lonelyone.git", "refs/heads/master")
+	if hash != "e0ab4048b87337a6b6d5b6ab051af2a00569a024" {
+		t.Error("commit hash dismatched")
+	}
+}


### PR DESCRIPTION
Fix the problems that git lastest commit hash depends on  gitlab RSS subscription.
The whole story: https://humorless.github.io/2017/03/15/get-latest-commit-hash-from-git-repo/
