### PR TITLE
[OWL-1333][OWL-1583] APIs for the cached target list

### DIFF
--- a/common/db/nqm/agent.go
+++ b/common/db/nqm/agent.go
@@ -405,9 +405,6 @@ func ListTargetsOfAgentById(query *nqmModel.TargetsOfAgentQuery, paging commonMo
 	if result == nil {
 		return nil, &paging
 	}
-	if paging.TotalCount == 0 {
-		return result, &paging
-	}
 
 	/**
 	 * Loads group tags
@@ -418,8 +415,8 @@ func ListTargetsOfAgentById(query *nqmModel.TargetsOfAgentQuery, paging commonMo
 	// :~)
 
 	result = &nqmModel.TargetsOfAgent{
-		CachedRefreshTime: ojson.JsonTime(resultOfCacheAgentPingListLog.CachedRefreshTime),
-		Targets:           resultOfTargets,
+		CacheRefreshTime: ojson.JsonTime(resultOfCacheAgentPingListLog.CachedRefreshTime),
+		Targets:          resultOfTargets,
 	}
 	return result, &paging
 }

--- a/common/db/nqm/agent.go
+++ b/common/db/nqm/agent.go
@@ -701,6 +701,16 @@ func init() {
 
 		return originFunc(entity)
 	}
+
+	originFunc = orderByDialectForAgentPingListTargets.FuncEntityToSyntax
+	orderByDialectForAgentPingListTargets.FuncEntityToSyntax = func(entity *commonModel.OrderByEntity) (string, error) {
+		switch entity.Expr {
+		case "group_tag":
+			return owlDb.GetSyntaxOfOrderByGroupTags(entity), nil
+		}
+
+		return originFunc(entity)
+	}
 }
 
 func buildSortingClauseOfAgentsWithPingTask(paging *commonModel.Paging) string {

--- a/common/db/nqm/agent.go
+++ b/common/db/nqm/agent.go
@@ -321,7 +321,6 @@ func ListTargetsOfAgentById(query *nqmModel.TargetsOfAgentQuery, paging commonMo
 	var result *nqmModel.TargetsOfAgent
 
 	var funcTxLoader gormExt.TxCallbackFunc = func(txGormDb *gorm.DB) commonDb.TxFinale {
-		//selectCacheAgentPingListLog := DbFacade.GormDb.First(&resultOfCacheAgentPingListLog, query.AgentID)
 		selectCacheAgentPingListLog := txGormDb.Model(&nqmModel.CacheAgentPingListLog{}).
 			Select(`
 				apll_ag_id, apll_time_refresh

--- a/common/db/nqm/agent_test.go
+++ b/common/db/nqm/agent_test.go
@@ -497,6 +497,27 @@ func (suite *TestAgentSuite) TestListTargetsOfAgentById(c *C) {
 	}
 }
 
+func (suite *TestAgentSuite) TestDeleteCachedTargetsOfAgentById(c *C) {
+	testCases := []*struct {
+		input    int32
+		expected int8
+	}{
+		{24021, 1},
+		{24021, 0},
+		{24022, 1},
+		{24022, 0},
+		{24023, 0},
+		{0, 0},
+	}
+	for i, testCase := range testCases {
+		if i == 5 {
+			c.Assert(DeleteCachedTargetsOfAgentById(testCase.input), IsNil, Commentf("Test Case: %d", i+1))
+			continue
+		}
+		c.Assert(DeleteCachedTargetsOfAgentById(testCase.input).RowsAffected, Equals, testCase.expected, Commentf("Test Case: %d", i+1))
+	}
+}
+
 // Tests the getting data of agent by id
 func (suite *TestAgentSuite) TestGetSimpleAgent1ById(c *C) {
 	testCases := []*struct {
@@ -749,6 +770,8 @@ func (s *TestAgentSuite) SetUpTest(c *C) {
 		)
 	case "TestAgentSuite.TestListTargetsOfAgentById":
 		inTx(nqmTestingDb.InitNqmCacheAgentPingList...)
+	case "TestAgentSuite.TestDeleteCachedTargetsOfAgentById":
+		inTx(nqmTestingDb.InitNqmCacheAgentPingList...)
 	}
 }
 func (s *TestAgentSuite) TearDownTest(c *C) {
@@ -836,6 +859,8 @@ func (s *TestAgentSuite) TearDownTest(c *C) {
 			"DELETE FROM owl_group_tag WHERE gt_name LIKE 'ng-%'",
 		)
 	case "TestAgentSuite.TestListTargetsOfAgentById":
+		inTx(nqmTestingDb.ClearNqmCacheAgentPingList...)
+	case "TestAgentSuite.TestDeleteCachedTargetsOfAgentById":
 		inTx(nqmTestingDb.ClearNqmCacheAgentPingList...)
 	}
 }

--- a/common/db/nqm/agent_test.go
+++ b/common/db/nqm/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"reflect"
 
+	nqmTestingDb "github.com/Cepave/open-falcon-backend/common/db/nqm/testing"
 	owlDb "github.com/Cepave/open-falcon-backend/common/db/owl"
 	commonModel "github.com/Cepave/open-falcon-backend/common/model"
 	nqmModel "github.com/Cepave/open-falcon-backend/common/model/nqm"
@@ -20,21 +21,21 @@ var _ = Suite(&TestAgentSuite{})
 // Tests the updating of agent
 func (suite *TestAgentSuite) TestUpdateAgent(c *C) {
 	modifiedAgent := &nqmModel.AgentForAdding{
-		Name:         utils.PointerOfCloneString("new-name-1"),
-		Comment:      utils.PointerOfCloneString("new-comment-1"),
-		Status:       false,
-		ProvinceId:   27,
-		CityId:       205,
-		IspId:        8,
+		Name:       utils.PointerOfCloneString("new-name-1"),
+		Comment:    utils.PointerOfCloneString("new-comment-1"),
+		Status:     false,
+		ProvinceId: 27,
+		CityId:     205,
+		IspId:      8,
 	}
 
 	sPtr := func(v string) *string { return &v }
 	testCases := []*struct {
-		nameTag *string
+		nameTag   *string
 		groupTags []string
-	} {
-		{ sPtr("nt-2"), []string{"ng-2", "ng-3", "ng-4"} },
-		{ nil, []string{} },
+	}{
+		{sPtr("nt-2"), []string{"ng-2", "ng-3", "ng-4"}},
+		{nil, []string{}},
 	}
 
 	for i, testCase := range testCases {
@@ -187,29 +188,29 @@ func (suite *TestAgentSuite) TestListAgents(c *C) {
 		},
 		{ // Match 1 row by all of the conditions
 			&nqmModel.AgentQuery{
-				Name:         "ag-name-1",
-				ConnectionId: "ag-list-1",
-				Hostname:     "hn-list-1",
-				IspId:        3,
-				HasIspIdParam: true,
-				IpAddress:    "123.52",
-				HasStatusParam:    true,
-				Status:       true,
+				Name:           "ag-name-1",
+				ConnectionId:   "ag-list-1",
+				Hostname:       "hn-list-1",
+				IspId:          3,
+				HasIspIdParam:  true,
+				IpAddress:      "123.52",
+				HasStatusParam: true,
+				Status:         true,
 			}, 10, 1, 1, 1,
 		},
 		{ // Match 1 row(by special IP address)
 			&nqmModel.AgentQuery{
-				IspId:     -2,
+				IspId:          -2,
 				HasStatusParam: false,
-				IpAddress: "12.37",
+				IpAddress:      "12.37",
 			}, 10, 1, 1, 1,
 		},
 		{ // Match nothing
 			&nqmModel.AgentQuery{
-				IspId:        -2,
-				HasStatusParam:    false,
-				ConnectionId: "ag-list-1",
-				Hostname:     "hn-list-2",
+				IspId:          -2,
+				HasStatusParam: false,
+				ConnectionId:   "ag-list-1",
+				Hostname:       "hn-list-2",
 			}, 10, 1, 0, 0,
 		},
 	}
@@ -272,29 +273,29 @@ func (suite *TestAgentSuite) TestListAgentsWithPingTask(c *C) {
 		},
 		{ // Match 1 row by all of the conditions
 			&nqmModel.AgentQuery{
-				Name:         "ag-name-1",
-				ConnectionId: "ag-list-1",
-				Hostname:     "hn-list-1",
-				IspId:        3,
-				IpAddress:    "123.52",
-				HasStatusParam:    true,
-				Status:       true,
+				Name:           "ag-name-1",
+				ConnectionId:   "ag-list-1",
+				Hostname:       "hn-list-1",
+				IspId:          3,
+				IpAddress:      "123.52",
+				HasStatusParam: true,
+				Status:         true,
 			},
 			10, 1, 1, 1,
 		},
 		{ // Match 1 row(by special IP address)
 			&nqmModel.AgentQuery{
-				IspId:     -2,
+				IspId:          -2,
 				HasStatusParam: false,
-				IpAddress: "12.37",
+				IpAddress:      "12.37",
 			}, 10, 1, 1, 1,
 		},
 		{ // Match nothing
 			&nqmModel.AgentQuery{
-				IspId:        -2,
-				HasStatusParam:    false,
-				ConnectionId: "ag-list-1",
-				Hostname:     "hn-list-2",
+				IspId:          -2,
+				HasStatusParam: false,
+				ConnectionId:   "ag-list-1",
+				Hostname:       "hn-list-2",
 			}, 10, 1, 0, 0,
 		},
 	}
@@ -352,6 +353,147 @@ func (suite *TestAgentSuite) TestListAgentsWithPingTask(c *C) {
 			c.Assert(testedResult, HasLen, testCase.expectedCountOfCurrentPage)
 			c.Assert(newPaging.TotalCount, Equals, testCase.expectedCountOfAll)
 		}
+	}
+}
+
+func (suite *TestAgentSuite) TestListTargetsOfAgentById(c *C) {
+	testCases := []*struct {
+		query                      *nqmModel.TargetsOfAgentQuery
+		pageSize                   int32
+		pagePosition               int32
+		expectedCountOfCurrentPage int
+		expectedCountOfAll         int32
+	}{
+		{ // All data
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID: 24021,
+				TargetQuery: &nqmModel.TargetQuery{
+					IspId:          -2,
+					HasStatusParam: false,
+				},
+			},
+			10, 1, 3, 3,
+		},
+		{ // 2nd page
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID: 24021,
+				TargetQuery: &nqmModel.TargetQuery{
+					IspId:          -2,
+					HasStatusParam: false,
+				},
+			},
+			2, 2, 1, 3,
+		},
+		{ // Match nothing for futher page
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID: 24021,
+				TargetQuery: &nqmModel.TargetQuery{
+					IspId:          -2,
+					HasStatusParam: false,
+				},
+			},
+			10, 10, 0, 3,
+		},
+		{ // Match 1 row by all of the conditions
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID: 24021,
+				TargetQuery: &nqmModel.TargetQuery{
+					Name:           "tg-name-1",
+					Host:           "tg-host-1",
+					IspId:          3,
+					HasStatusParam: true,
+					Status:         true,
+				},
+			}, 10, 1, 1, 1,
+		},
+		{ // Match 1 row(by ISP id)
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID: 24021,
+				TargetQuery: &nqmModel.TargetQuery{
+					IspId:         5,
+					HasIspIdParam: true,
+				},
+			}, 10, 1, 1, 1,
+		},
+		{ // Match nothing
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID: 24021,
+				TargetQuery: &nqmModel.TargetQuery{
+					IspId:          -2,
+					HasStatusParam: false,
+					Name:           "tg-easy-1",
+					Host:           "tg-host-1",
+				},
+			}, 10, 1, 0, 0,
+		},
+		{ // Zero targets
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID:     24022,
+				TargetQuery: &nqmModel.TargetQuery{},
+			}, 10, 1, 0, 0,
+		},
+		{ // Agent not existent
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID:     0,
+				TargetQuery: &nqmModel.TargetQuery{},
+			}, 10, 1, 0, 0,
+		},
+		{ // Agent existent but not in cache
+			&nqmModel.TargetsOfAgentQuery{
+				AgentID:     24023,
+				TargetQuery: &nqmModel.TargetQuery{},
+			}, 10, 1, 0, 0,
+		},
+	}
+
+	for i, testCase := range testCases {
+		paging := commonModel.Paging{
+			Size:     testCase.pageSize,
+			Position: testCase.pagePosition,
+			OrderBy: []*commonModel.OrderByEntity{
+				&commonModel.OrderByEntity{"id", commonModel.Descending},
+				&commonModel.OrderByEntity{"name", commonModel.Ascending},
+				&commonModel.OrderByEntity{"status", commonModel.Ascending},
+				&commonModel.OrderByEntity{"host", commonModel.Ascending},
+				&commonModel.OrderByEntity{"comment", commonModel.Ascending},
+				&commonModel.OrderByEntity{"isp", commonModel.Ascending},
+				&commonModel.OrderByEntity{"province", commonModel.Ascending},
+				&commonModel.OrderByEntity{"city", commonModel.Ascending},
+				&commonModel.OrderByEntity{"creation_time", commonModel.Ascending},
+				&commonModel.OrderByEntity{"name_tag", commonModel.Ascending},
+				//&commonModel.OrderByEntity{"group_tag", commonModel.Descending},
+				&commonModel.OrderByEntity{"probed_time", commonModel.Descending},
+			},
+		}
+
+		testedResult, newPaging := ListTargetsOfAgentById(
+			testCase.query, paging,
+		)
+
+		//if i == 6 { // AgentID not existent
+		//	c.Assert(len(testedResult.Targets), Equals, 0)
+		//	continue
+		//}
+
+		if i == 7 { // AgentID not existent
+			c.Assert(testedResult, IsNil)
+			continue
+		}
+
+		if i == 8 { // AgentID existent but not in cache
+			tStr, _ := testedResult.CacheRefreshTime.MarshalJSON()
+			c.Assert(tStr, DeepEquals, []byte("null"))
+			continue
+		}
+
+		c.Logf("[List] Query condition: %v. Number of targets: %d", testCase.query, len(testedResult.Targets))
+
+		for _, target := range testedResult.Targets {
+			c.Logf("[List] Target: %v.", target)
+		}
+		c.Assert(testedResult.Targets, HasLen, testCase.expectedCountOfCurrentPage, Commentf("Test Case: %d", i+1))
+		c.Assert(newPaging.TotalCount, Equals, testCase.expectedCountOfAll, Commentf("Test Case: %d", i+1))
+		// testedResult.CacheRefreshTime
 	}
 }
 
@@ -605,6 +747,8 @@ func (s *TestAgentSuite) SetUpTest(c *C) {
 			VALUES(10061, 37201),(10061, 37202)
 			`,
 		)
+	case "TestAgentSuite.TestListTargetsOfAgentById":
+		inTx(nqmTestingDb.InitNqmCacheAgentPingList...)
 	}
 }
 func (s *TestAgentSuite) TearDownTest(c *C) {
@@ -691,6 +835,8 @@ func (s *TestAgentSuite) TearDownTest(c *C) {
 			"DELETE FROM owl_name_tag WHERE nt_value LIKE 'nt-%'",
 			"DELETE FROM owl_group_tag WHERE gt_name LIKE 'ng-%'",
 		)
+	case "TestAgentSuite.TestListTargetsOfAgentById":
+		inTx(nqmTestingDb.ClearNqmCacheAgentPingList...)
 	}
 }
 

--- a/common/db/nqm/agent_test.go
+++ b/common/db/nqm/agent_test.go
@@ -461,7 +461,7 @@ func (suite *TestAgentSuite) TestListTargetsOfAgentById(c *C) {
 				&commonModel.OrderByEntity{"city", commonModel.Ascending},
 				&commonModel.OrderByEntity{"creation_time", commonModel.Ascending},
 				&commonModel.OrderByEntity{"name_tag", commonModel.Ascending},
-				//&commonModel.OrderByEntity{"group_tag", commonModel.Descending},
+				&commonModel.OrderByEntity{"group_tag", commonModel.Descending},
 				&commonModel.OrderByEntity{"probed_time", commonModel.Descending},
 			},
 		}

--- a/common/db/nqm/testing/db.go
+++ b/common/db/nqm/testing/db.go
@@ -18,6 +18,41 @@ VALUES(36091, 'ct-agent-1', '', ''),
 `
 var DeleteHostSQL = `DELETE FROM host WHERE id >= 36091 AND id <= 36095`
 
+var InsertOwlNameTag = `
+INSERT INTO owl_name_tag(nt_id, nt_value)
+VALUES(3081, '美國 IP 群')
+`
+
+var DeleteOwlNameTag = `DELETE FROM owl_name_tag WHERE nt_id = 3081`
+
+var InsertOwlGroupTag = `
+INSERT INTO owl_group_tag(gt_id, gt_name)
+VALUES
+	(23401, '串流一網'),
+	(23402, '串流二 網')
+`
+
+var DeleteOwlGroupTag = `DELETE FROM owl_group_tag WHERE gt_id >= 23401 AND gt_id <= 23402`
+
+var InsertNqmTarget = `
+INSERT INTO nqm_target(tg_id, tg_name, tg_host, tg_available, tg_status, tg_isp_id, tg_nt_id)
+VALUES
+	(40201, 'tg-name-1', 'tg-host-1', false, true, 3, -1),
+	(40202, 'tg-name-2', 'tg-host-2', true, true, 4, 3081),
+	(40203, 'tg-name-3', 'tg-host-3', true, false, 5, -1)
+`
+var DeleteNqmTarget = `DELETE FROM nqm_target WHERE tg_id >= 40201 AND tg_id <= 40203`
+
+var InsertNqmTargetGroupTag = `
+INSERT INTO nqm_target_group_tag(tgt_tg_id, tgt_gt_id)
+VALUES
+	(40201, 23401),
+	(40201, 23402)
+`
+
+var InitNqmTarget = []string{InsertOwlNameTag, InsertOwlGroupTag, InsertNqmTarget, InsertNqmTargetGroupTag}
+var ClearNqmTarget = []string{DeleteNqmTarget, DeleteOwlNameTag, DeleteOwlGroupTag}
+
 var InsertNqmAgentSQL = `
 INSERT INTO nqm_agent(
 	ag_id, ag_hs_id, ag_name, ag_connection_id, ag_hostname, ag_ip_address,
@@ -32,3 +67,38 @@ var DeleteNqmAgentSQL = `DELETE FROM nqm_agent WHERE ag_id >= 24021 AND ag_id <=
 
 var InitNqmAgentAndPingtaskSQL = []string{InsertPingtaskSQL, InsertHostSQL, InsertNqmAgentSQL}
 var CleanNqmAgentAndPingtaskSQL = []string{DeleteNqmAgentPingtaskSQL, DeleteNqmAgentSQL, DeleteHostSQL, DeletePingtaskSQL}
+
+var InitNqmAgent = []string{InsertHostSQL, InsertNqmAgentSQL}
+var ClearNqmAgent = []string{DeleteNqmAgentSQL, DeleteHostSQL}
+
+var InsertNqmCacheAgentPingListLog = `
+INSERT INTO nqm_cache_agent_ping_list_log(
+	apll_ag_id, apll_number_of_targets, apll_time_access, apll_time_refresh
+)
+VALUES
+	(24021, 3, '2017-01-01', '2017-01-01'),
+	(24022, 0, '2017-01-01', '2017-01-01')
+`
+
+var DeleteNqmCacheAgentPingListLog = `
+DELETE FROM nqm_cache_agent_ping_list_log
+WHERE apll_ag_id>= 24021 AND  apll_ag_id<= 24022
+`
+
+var InsertNqmCacheAgentPingList = `
+INSERT INTO nqm_cache_agent_ping_list(
+	apl_apll_ag_id, apl_tg_id, apl_min_period, apl_time_access
+)
+VALUES
+	(24021, 40201, 1, '2017-01-01'),
+	(24021, 40202, 1, '2017-01-01'),
+	(24021, 40203, 1, '2017-01-01')
+`
+
+var InitNqmCacheAgentPingListLog = []string{InsertHostSQL, InsertNqmAgentSQL, InsertNqmCacheAgentPingListLog}
+
+var ClearNqmCacheAgentPingListLog = []string{DeleteNqmCacheAgentPingListLog, DeleteNqmAgentSQL, DeleteHostSQL}
+
+var InitNqmCacheAgentPingList = []string{InsertHostSQL, InsertNqmAgentSQL, InsertNqmCacheAgentPingListLog, InsertOwlNameTag, InsertOwlGroupTag, InsertNqmTarget, InsertNqmTargetGroupTag, InsertNqmCacheAgentPingList}
+
+var ClearNqmCacheAgentPingList = []string{DeleteNqmCacheAgentPingListLog, DeleteNqmAgentSQL, DeleteHostSQL, DeleteNqmTarget, DeleteOwlNameTag, DeleteOwlGroupTag}

--- a/common/model/nqm/agent.go
+++ b/common/model/nqm/agent.go
@@ -25,7 +25,7 @@ type AgentForAdding struct {
 	ProvinceId int16 `json:"province_id" validate:"nonZeroId"`
 	CityId     int16 `json:"city_id" validate:"nonZeroId"`
 
-	NameTagId    int16  `json:"-"`
+	NameTagId    int16   `json:"-"`
 	NameTagValue *string `json:"name_tag" conform:"trim"`
 
 	GroupTags []string `json:"group_tags" conform:"trim"`
@@ -237,8 +237,9 @@ func (CacheAgentPingListLog) TableName() string {
 }
 
 type TargetsOfAgent struct {
-	CachedRefreshTime ojson.JsonTime `json:"cached_refresh_time"`
-	Targets           []*Target      `json:"targets"`
+	CacheRefreshTime ojson.JsonTime `json:"cache_refresh_time"`
+	CacheLifeTime    int            `json:"cache_lifetime"`
+	Targets          []*Target      `json:"targets"`
 }
 
 func (l *PingListLog) GetDurationOfLastAccess(checkedTime time.Time) int64 {

--- a/common/model/nqm/agent.go
+++ b/common/model/nqm/agent.go
@@ -12,11 +12,11 @@ import (
 )
 
 type AgentForAdding struct {
-	Id           int32  `json:"-"`
+	Id           int32   `json:"-"`
 	Name         *string `json:"name" conform:"trimToNil"`
 	Comment      *string `json:"comment" conform:"trimToNil"`
-	ConnectionId string `json:"connection_id" conform:"trim" validate:"min=1"`
-	Status       bool   `json:"status"`
+	ConnectionId string  `json:"connection_id" conform:"trim" validate:"min=1"`
+	Status       bool    `json:"status"`
 
 	Hostname  string `json:"hostname" conform:"trim" validate:"min=1"`
 	IpAddress net.IP `json:"-"`
@@ -62,16 +62,16 @@ func (agent *AgentForAdding) GetIpAddressAsString() string {
 }
 
 type Agent struct {
-	Id                    int32  `gorm:"primary_key:true;column:ag_id"`
+	Id                    int32   `gorm:"primary_key:true;column:ag_id"`
 	Name                  *string `gorm:"column:ag_name"`
-	ConnectionId          string `gorm:"column:ag_connection_id""`
-	Hostname              string `gorm:"column:ag_hostname"`
-	NumOfEnabledPingtasks int32  `gorm:"column:ag_num_of_enabled_pingtasks"`
+	ConnectionId          string  `gorm:"column:ag_connection_id""`
+	Hostname              string  `gorm:"column:ag_hostname"`
+	NumOfEnabledPingtasks int32   `gorm:"column:ag_num_of_enabled_pingtasks"`
 
 	IpAddress net.IP `gorm:"column:ag_ip_address"`
 
 	Status        bool      `gorm:"column:ag_status"`
-	Comment       *string    `gorm:"column:ag_comment"`
+	Comment       *string   `gorm:"column:ag_comment"`
 	LastHeartBeat time.Time `gorm:"column:ag_last_heartbeat"`
 
 	IspId   int16  `gorm:"column:isp_id"`
@@ -225,6 +225,20 @@ type PingListLog struct {
 	NumberOfTargets int32     `db:"apll_number_of_targets"`
 	AccessTime      time.Time `db:"apll_time_access"`
 	RefreshTime     time.Time `db:"apll_time_refresh"`
+}
+
+type CacheAgentPingListLog struct {
+	ApllAgId          int32     `gorm:"primary_key:true;column:apll_ag_id"`
+	CachedRefreshTime time.Time `gorm:"column:apll_time_refresh"`
+}
+
+func (CacheAgentPingListLog) TableName() string {
+	return "nqm_cache_agent_ping_list_log"
+}
+
+type TargetsOfAgent struct {
+	CachedRefreshTime ojson.JsonTime `json:"cached_refresh_time"`
+	Targets           []*Target      `json:"targets"`
 }
 
 func (l *PingListLog) GetDurationOfLastAccess(checkedTime time.Time) int64 {

--- a/common/model/nqm/agent.go
+++ b/common/model/nqm/agent.go
@@ -237,10 +237,55 @@ func (CacheAgentPingListLog) TableName() string {
 	return "nqm_cache_agent_ping_list_log"
 }
 
+type AgentPingListTarget struct {
+	Target
+	AgentPingListTimeAccess time.Time      `gorm:"column:tg_apl_time_access"`
+	ProbedTime              ojson.JsonTime //`json:"probed_time"`
+}
+
+func (target *AgentPingListTarget) MarshalJSON() ([]byte, error) {
+	jsonObject := json.New()
+
+	jsonObject.Set("id", target.Id)
+	jsonObject.Set("name", target.Name)
+	jsonObject.Set("host", target.Host)
+	jsonObject.Set("probed_by_all", target.ProbedByAll)
+	jsonObject.Set("status", target.Status)
+	jsonObject.Set("available", target.Available)
+	jsonObject.Set("creation_time", target.CreationTime.Unix())
+	jsonObject.Set("comment", target.Comment)
+	jsonObject.Set("probed_time", target.ProbedTime)
+
+	jsonIsp := json.New()
+	jsonIsp.Set("id", target.IspId)
+	jsonIsp.Set("name", target.IspName)
+	jsonObject.Set("isp", jsonIsp)
+
+	jsonProvince := json.New()
+	jsonProvince.Set("id", target.ProvinceId)
+	jsonProvince.Set("name", target.ProvinceName)
+	jsonObject.Set("province", jsonProvince)
+
+	jsonCity := json.New()
+	jsonCity.Set("id", target.CityId)
+	jsonCity.Set("name", target.CityName)
+	jsonObject.Set("city", jsonCity)
+
+	jsonNameTag := json.New()
+	jsonNameTag.Set("id", target.NameTagId)
+	jsonNameTag.Set("value", target.NameTagValue)
+	jsonObject.Set("name_tag", jsonNameTag)
+
+	jsonGroupTags := owlModel.GroupTags(target.GroupTags).ToJson()
+	jsonObject.Set("group_tags", jsonGroupTags)
+
+	return jsonObject.MarshalJSON()
+}
+
 type TargetsOfAgent struct {
-	CacheRefreshTime ojson.JsonTime `json:"cache_refresh_time"`
-	CacheLifeTime    int            `json:"cache_lifetime"`
-	Targets          []*Target      `json:"targets"`
+	CacheRefreshTime ojson.JsonTime         `json:"cache_refresh_time"`
+	CacheLifeTime    int                    `json:"cache_lifetime"`
+	Targets          []*AgentPingListTarget `json:"targets"`
 }
 
 type ClearCacheView struct {

--- a/common/model/nqm/agent.go
+++ b/common/model/nqm/agent.go
@@ -107,6 +107,7 @@ func (agentView *Agent) ToSimpleJson() *json.Json {
 	jsonObject.Set("last_heartbeat_time", ojson.JsonTime(agentView.LastHeartBeat))
 	jsonObject.Set("name", agentView.Name)
 	jsonObject.Set("comment", agentView.Comment)
+	jsonObject.Set("num_of_enabled_pingtasks", agentView.NumOfEnabledPingtasks)
 
 	jsonIsp := json.New()
 	jsonIsp.Set("id", agentView.IspId)

--- a/common/model/nqm/agent.go
+++ b/common/model/nqm/agent.go
@@ -243,6 +243,10 @@ type TargetsOfAgent struct {
 	Targets          []*Target      `json:"targets"`
 }
 
+type ClearCacheView struct {
+	RowsAffected int8 `json:"rows_affected"`
+}
+
 func (l *PingListLog) GetDurationOfLastAccess(checkedTime time.Time) int64 {
 	return int64(checkedTime.Sub(l.AccessTime) / time.Minute)
 }

--- a/common/model/nqm/query.go
+++ b/common/model/nqm/query.go
@@ -11,10 +11,10 @@ type AgentQuery struct {
 	Hostname     string `mvc:"query[hostname]" conform:"trim"`
 	IpAddress    string `mvc:"query[ip_address]" conform:"trim"`
 
-	IspId int16 `mvc:"query[isp_id]"`
-	HasIspIdParam bool `mvc:"query[?isp_id]"`
+	IspId         int16 `mvc:"query[isp_id]"`
+	HasIspIdParam bool  `mvc:"query[?isp_id]"`
 
-	Status    bool  `mvc:"query[status]"`
+	Status         bool `mvc:"query[status]"`
 	HasStatusParam bool `mvc:"query[?status]"`
 }
 
@@ -39,16 +39,21 @@ func (query *AgentQueryWithPingTask) HasAppliedCondition() bool {
 	return query.HasApplied != "!N!"
 }
 
+type TargetsOfAgentQuery struct {
+	AgentID     int32 `mvc:"param[agent_id]"`
+	TargetQuery *TargetQuery
+}
+
 // The query conditions of target
 type TargetQuery struct {
-	Name               string `mvc:"query[name]"`
-	Host               string `mvc:"query[host]"`
+	Name string `mvc:"query[name]"`
+	Host string `mvc:"query[host]"`
 
-	IspId              int16 `mvc:"query[isp_id]"`
-	HasIspIdParam		bool `mvc:"query[?isp_id]"`
+	IspId         int16 `mvc:"query[isp_id]"`
+	HasIspIdParam bool  `mvc:"query[?isp_id]"`
 
-	Status             bool `mvc:"query[status]"`
-	HasStatusParam     bool `mvc:"query[?status]"`
+	Status         bool `mvc:"query[status]"`
+	HasStatusParam bool `mvc:"query[?status]"`
 }
 
 type AgentFilter struct {

--- a/modules/nqm-mng/cfg.example.json
+++ b/modules/nqm-mng/cfg.example.json
@@ -1,6 +1,6 @@
 {
 	"rdb" : {
-		"dsn" : "root:cepave@tcp(192.168.20.50:3306)/falcon_portal?loc=Local&parseTime=true",
+		"dsn" : "root:cepave@tcp(127.0.0.1:3306)/falcon_portal?loc=Local&parseTime=true",
 		"maxIdle" : 8
 	},
 	"restful" : {
@@ -11,5 +11,12 @@
 	},
 	"logLevel" : {
 		"ROOT" : "INFO"
+	},
+	"nqm" :{
+		"pingList": {
+			"cache": {
+				"size": 8,
+				"lifetime": 20
+		}
 	}
 }

--- a/modules/nqm-mng/main.go
+++ b/modules/nqm-mng/main.go
@@ -33,6 +33,7 @@ func main() {
 
 	rdb.InitRdb(toRdbConfig(config))
 	restful.InitGin(toGinConfig(config))
+	restful.InitCache(toCacheConfig(config))
 
 	commonOs.HoldingAndWaitSignal(exitApp, syscall.SIGINT, syscall.SIGTERM)
 }
@@ -48,10 +49,18 @@ func toGinConfig(config *viper.Viper) *commonGin.GinConfig {
 		Port: uint16(config.GetInt("restful.listen.port")),
 	}
 }
+
 func toRdbConfig(config *viper.Viper) *commonDb.DbConfig {
 	return &commonDb.DbConfig{
 		Dsn:     config.GetString("rdb.dsn"),
 		MaxIdle: config.GetInt("rdb.maxIdle"),
+	}
+}
+
+func toCacheConfig(config *viper.Viper) *restful.CacheConfig {
+	return &restful.CacheConfig{
+		Size:     config.GetInt("nqm.pingList.cache.size"),
+		Lifetime: config.GetInt("nqm.pingList.cache.lifetime"),
 	}
 }
 

--- a/modules/nqm-mng/restful/agent.go
+++ b/modules/nqm-mng/restful/agent.go
@@ -108,7 +108,10 @@ func listTargetsOfAgentById(
 	},
 ) (*commonModel.Paging, mvc.OutputBody) {
 	p.Paging = commonGin.PagingByHeader(c, p.Paging)
-	targets, resultPaging := commonNqmDb.ListTargetsOfAgentById(q, *p.Paging)
+	targetList, resultPaging := commonNqmDb.ListTargetsOfAgentById(q, *p.Paging)
+	if targetList != nil {
+		targetList.CacheLifeTime = cacheConfig.Lifetime
+	}
 
-	return resultPaging, mvc.JsonOutputOrNotFound(targets)
+	return resultPaging, mvc.JsonOutputOrNotFound(targetList)
 }

--- a/modules/nqm-mng/restful/agent.go
+++ b/modules/nqm-mng/restful/agent.go
@@ -99,3 +99,16 @@ func listAgents(
 
 	return resultPaging, mvc.JsonOutputBody(agents)
 }
+
+func listTargetsOfAgentById(
+	c *gin.Context,
+	q *commonNqmModel.TargetsOfAgentQuery,
+	p *struct {
+		Paging *commonModel.Paging `mvc:"pageSize[50] pageOrderBy[status#desc:name#asc:host#asc]"`
+	},
+) (*commonModel.Paging, mvc.OutputBody) {
+	p.Paging = commonGin.PagingByHeader(c, p.Paging)
+	targets, resultPaging := commonNqmDb.ListTargetsOfAgentById(q, *p.Paging)
+
+	return resultPaging, mvc.JsonOutputOrNotFound(targets)
+}

--- a/modules/nqm-mng/restful/agent.go
+++ b/modules/nqm-mng/restful/agent.go
@@ -115,3 +115,12 @@ func listTargetsOfAgentById(
 
 	return resultPaging, mvc.JsonOutputOrNotFound(targetList)
 }
+
+func clearCachedTargetsOfAgentById(
+	q *struct {
+		AgentID int32 `mvc:"param[agent_id]"`
+	},
+) mvc.OutputBody {
+	r := commonNqmDb.DeleteCachedTargetsOfAgentById(q.AgentID)
+	return mvc.JsonOutputOrNotFound(r)
+}

--- a/modules/nqm-mng/restful/package.go
+++ b/modules/nqm-mng/restful/package.go
@@ -39,6 +39,7 @@ func initApi() {
 	v1.PUT("/nqm/agent/:agent_id", modifyAgent)
 	v1.POST("/nqm/agent/:agent_id/pingtask", addPingtaskToAgentForAgent)
 	v1.DELETE("/nqm/agent/:agent_id/pingtask/:pingtask_id", removePingtaskFromAgentForAgent)
+	v1.GET("/nqm/agent/:agent_id/targets", mvcBuilder.BuildHandler(listTargetsOfAgentById))
 
 	v1.GET("/nqm/pingtasks", mvcBuilder.BuildHandler(listPingtasks))
 	v1.GET("/nqm/pingtask/:pingtask_id", mvcBuilder.BuildHandler(getPingtasksById))

--- a/modules/nqm-mng/restful/package.go
+++ b/modules/nqm-mng/restful/package.go
@@ -28,6 +28,17 @@ func InitGin(config *commonGin.GinConfig) {
 	*GinConfig = *config
 }
 
+type CacheConfig struct {
+	Size     int
+	Lifetime int
+}
+
+var cacheConfig *CacheConfig = &CacheConfig{}
+
+func InitCache(config *CacheConfig) {
+	cacheConfig = config
+}
+
 func initApi() {
 	mvcBuilder := mvc.NewMvcBuilder(mvc.NewDefaultMvcConfig())
 

--- a/modules/nqm-mng/restful/package.go
+++ b/modules/nqm-mng/restful/package.go
@@ -51,6 +51,7 @@ func initApi() {
 	v1.POST("/nqm/agent/:agent_id/pingtask", addPingtaskToAgentForAgent)
 	v1.DELETE("/nqm/agent/:agent_id/pingtask/:pingtask_id", removePingtaskFromAgentForAgent)
 	v1.GET("/nqm/agent/:agent_id/targets", mvcBuilder.BuildHandler(listTargetsOfAgentById))
+	v1.POST("/nqm/agent/:agent_id/targets/clear", mvcBuilder.BuildHandler(clearCachedTargetsOfAgentById))
 
 	v1.GET("/nqm/pingtasks", mvcBuilder.BuildHandler(listPingtasks))
 	v1.GET("/nqm/pingtask/:pingtask_id", mvcBuilder.BuildHandler(getPingtasksById))


### PR DESCRIPTION
In this PR, two APIs are implemented. One is for getting the cached target list, the other is for clearing the cache. These two APIs, which are given the agent ID by the URLs, are for a specific agent.
