### PR TITLE
[OWL-1662][agent] let agent to allow different endpoint in plugin script

### DIFF
--- a/modules/agent/plugins/scheduler.go
+++ b/modules/agent/plugins/scheduler.go
@@ -187,8 +187,10 @@ func PluginRun(plugin *Plugin) {
 
 	for j := 0; j < len(metrics); j++ {
 		metrics[j].Step = int64(sec)
-		metrics[j].Endpoint = hostname
 		metrics[j].Timestamp = now
+		if metrics[j].Endpoint == "" {
+			metrics[j].Endpoint = hostname
+		}
 	}
 
 	g.SendToTransfer(metrics)


### PR DESCRIPTION
原本的這段程式碼
https://github.com/Cepave/open-falcon-backend/commit/4244fa6f56f4d6d0c9193c8913a0c1d6917548e3
這是為了防呆，希望可以做欄位補齊。

後來發現這樣子改之後，plugin script 裡的 endpoint 欄位會備受限制，無法使用非 hostname 的值。所以做這次的修正。
