### PR TITLE
change endpoint_id temp store variable's type to int64

### DIFF
--- a/modules/f2e-api/app/controller/graph/owl_graph_controller.go
+++ b/modules/f2e-api/app/controller/graph/owl_graph_controller.go
@@ -94,7 +94,7 @@ func EndpointsQuerySubMetric(c *gin.Context) {
 		inputs.MetricQuery = ".+"
 	}
 	enps := inputs.Endpoints
-	enpids := []int{}
+	enpids := []int64{}
 	db.Graph.Table("endpoint").Select("id").Where("endpoint IN (?)", enps).Pluck("id", &enpids)
 	metricSlist := map[string]int{}
 	if len(enpids) != 0 {


### PR DESCRIPTION
change endpoint_id temp store variable's type to int64, cause we saved big number on graph database