### PR TITLE
[OWL-1206] disable the function `updateHostsTable` and use `boss.py` to replace it.

### DIFF
--- a/modules/query/http/cron.go
+++ b/modules/query/http/cron.go
@@ -960,7 +960,7 @@ func syncHostsTable() {
 	sort.Strings(platformNames)
 	log.Debugf("platformNames =", platformNames)
 	updateIPsTable(IPKeys, IPsMap)
-	updateHostsTable(hostnames, hostsMap)
+	// updateHostsTable(hostnames, hostsMap)
 	platformsMap = getPlatformsType(nodes, result, platformsMap)
 	updatePlatformsTable(platformNames, platformsMap)
 	muteFalconHostTable(hostnames, hostsMap)


### PR DESCRIPTION
1.  Most of the cronjobs currently staying at query should be moved out to better place. 
2.  Currently, the original `updateHostsTable`  takes more than one minute to finish. The SQL is far from optimal. 
3.  In `boss.py`, I use temp table to optimize the [SQL commands](https://github.com/humorless/OWL-1206/). 
4.  In my test, `boss.py` takes about 16 seconds to finish the SQL update. 