### PR TITLE
[OWL-1766] Based on design of New graph/screen page changes f2e-api's api

### DIFF
--- a/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_controller.go
@@ -12,40 +12,14 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type APIGraphCreateReqData struct {
-	ScreenId   int64    `json:"screen_id" form:"screen_id" binding:"required"`
-	Title      string   `json:"title" form:"title" binding:"required"`
-	Endpoints  []string `json:"endpoints" form:"endpoints" binding:"required"`
-	Counters   []string `json:"counters" form:"counters" binding:"required"`
-	TimeSpan   int64    `json:"timespan" form:"timespan"`
-	GraphType  string   `json:"graph_type" form:"graph_type" binding:"required"`
-	Method     string   `json:"method" form:"method"`
-	Position   int64    `json:"position" form:"position"`
-	FalconTags string   `json:"falcon_tags" form:"falcon_tags"`
-}
-
-func (mine APIGraphCreateReqData) Check() (err error) {
-	sc := m.DashboardScreen{ID: mine.ScreenId}
-	// check screen_id
-	if !sc.Exist() {
-		err = fmt.Errorf("screen id:%v is not existing", mine.ScreenId)
-		return
-	}
-
-	if mine.TimeSpan%60 != 0 {
-		err = fmt.Errorf("value of timespan is not vaild: %v", mine.TimeSpan)
-		return
-	}
-
-	if mine.GraphType != "h" && mine.GraphType != "k" && mine.GraphType != "a" {
-		err = fmt.Errorf("value of graph_type only accpet 'k' or 'h' or 'a', you typed: %v", mine.GraphType)
-		return
-	}
-	return
-}
-
 func DashboardGraphCreate(c *gin.Context) {
-	inputs := APIGraphCreateReqData{TimeSpan: 3600, GraphType: "h"}
+	//set default values
+	inputs := APIGraphCreateReqData{
+		TimeSpan:     3600,
+		TimeRange:    "3h",
+		GraphType:    "h",
+		SortBy:       "a-z",
+		SampleMethod: "AVERAGE"}
 	if err := c.Bind(&inputs); err != nil {
 		h.JSONR(c, badstatus, err)
 		return
@@ -53,6 +27,11 @@ func DashboardGraphCreate(c *gin.Context) {
 
 	if err := inputs.Check(); err != nil {
 		h.JSONR(c, badstatus, err)
+		return
+	}
+	screen := m.DashboardScreen{ID: inputs.ScreenId}
+	if !screen.Exist() {
+		h.JSONR(c, badstatus, fmt.Sprintf("screen id: %d record not found", screen.ID))
 		return
 	}
 	es := inputs.Endpoints
@@ -67,15 +46,19 @@ func DashboardGraphCreate(c *gin.Context) {
 		return
 	}
 	d := m.DashboardGraph{
-		Title:     inputs.Title,
-		Hosts:     esString,
-		Counters:  csString,
-		ScreenId:  int64(inputs.ScreenId),
-		TimeSpan:  inputs.TimeSpan,
-		GraphType: inputs.GraphType,
-		Method:    inputs.Method,
-		Position:  inputs.Position,
-		Creator:   user.Name,
+		Title:        inputs.Title,
+		Hosts:        esString,
+		Counters:     csString,
+		ScreenId:     int64(inputs.ScreenId),
+		TimeSpan:     inputs.TimeSpan,
+		GraphType:    inputs.GraphType,
+		Method:       inputs.Method,
+		Position:     inputs.Position,
+		Creator:      user.Name,
+		TimeRange:    inputs.TimeRange,
+		SampleMethod: inputs.SampleMethod,
+		SortBy:       inputs.SortBy,
+		YScale:       inputs.YScale,
 	}
 	dt := db.Dashboard.Begin()
 	dt = dt.Save(&d)
@@ -84,61 +67,21 @@ func DashboardGraphCreate(c *gin.Context) {
 		h.JSONR(c, badstatus, dt.Error)
 		return
 	}
-
-	var lid []int
-	dt = dt.Table(d.TableName()).Raw("select LAST_INSERT_ID() as id").Pluck("id", &lid)
-	if dt.Error != nil {
-		dt.Rollback()
-		h.JSONR(c, badstatus, dt.Error)
-		return
-	}
 	dt.Commit()
-	aid := lid[0]
-
-	h.JSONR(c, map[string]interface{}{"id": aid, "screen_id": d.ScreenId})
-
-}
-
-type APIGraphUpdateReqData struct {
-	ID         int64    `json:"id" form:"id" binding:"required"`
-	ScreenId   int64    `json:"screen_id" form:"screen_id"`
-	Title      string   `json:"title" form:"title"`
-	Endpoints  []string `json:"endpoints" form:"endpoints"`
-	Counters   []string `json:"counters" form:"counters"`
-	TimeSpan   int64    `json:"timespan" form:"timespan"`
-	GraphType  string   `json:"graph_type" form:"graph_type"`
-	Method     string   `json:"method" form:"method"`
-	Position   int64    `json:"position" form:"position"`
-	FalconTags string   `json:"falcon_tags" form:"falcon_tags"`
-}
-
-func (mine APIGraphUpdateReqData) Check() (err error) {
-	sc := m.DashboardScreen{ID: mine.ScreenId}
-	// check screen_id
-	if mine.ScreenId != 0 && !sc.Exist() {
-		err = fmt.Errorf("screen id:%v is not existing", mine.ScreenId)
-		return
-	}
-
-	if mine.ScreenId != 0 && mine.TimeSpan%60 != 0 {
-		err = fmt.Errorf("value of timespan is not vaild: %v", mine.TimeSpan)
-		return
-	}
-
-	if mine.GraphType != "" && mine.GraphType != "h" && mine.GraphType != "k" {
-		err = fmt.Errorf("value of graph_type only accpet 'k' or 'h', you typed: %v", mine.GraphType)
-		return
-	}
-	return
+	db.Dashboard.Model(&screen).Where("id = ?", screen.ID).Scan(&screen)
+	h.JSONR(c, map[string]interface{}{"graph": buildGraphGetOutput(d), "screen_id": screen.ID, "screen_name": screen.Name})
 }
 
 func DashboardGraphUpdate(c *gin.Context) {
-	inputs := APIGraphUpdateReqData{Method: "NaN", FalconTags: "NaN"}
+	inputs := APIGraphUpdateReqData{Method: "NULL", FalconTags: "NULL"}
 	if err := c.Bind(&inputs); err != nil {
 		h.JSONR(c, badstatus, err)
 		return
 	}
-
+	if err := inputs.Check(); err != nil {
+		h.JSONR(c, badstatus, err)
+		return
+	}
 	graph := m.DashboardGraph{ID: inputs.ID}
 	if dt := db.Dashboard.Model(&graph).Where("id = ?", inputs.ID).Scan(&graph); dt.Error != nil {
 		h.JSONR(c, badstatus, fmt.Errorf("get graph id:%d, got error:%s", inputs.ID, dt.Error.Error()))
@@ -170,7 +113,7 @@ func DashboardGraphUpdate(c *gin.Context) {
 		graph.GraphType = inputs.GraphType
 	}
 	//method accpect empty, this is means not SUM action
-	if inputs.Method != "NaN" {
+	if inputs.Method != "NULL" {
 		graph.Method = inputs.Method
 	} else {
 		graph.Method = ""
@@ -178,12 +121,24 @@ func DashboardGraphUpdate(c *gin.Context) {
 	if inputs.Position != 0 {
 		graph.Position = inputs.Position
 	}
-	if inputs.FalconTags != "NaN" {
+	if inputs.FalconTags != "NULL" {
 		graph.FalconTags = inputs.FalconTags
 	} else {
 		graph.FalconTags = ""
 	}
 
+	if inputs.TimeRange != "" {
+		graph.TimeRange = inputs.TimeRange
+	}
+	if inputs.SampleMethod != "" {
+		graph.SampleMethod = inputs.SampleMethod
+	}
+	if inputs.YScale != "" {
+		graph.YScale = inputs.YScale
+	}
+	if inputs.SortBy != "" {
+		graph.SortBy = inputs.SortBy
+	}
 	tx := db.Dashboard.Begin()
 	if dt := tx.Model(&graph).Where("id = ?", inputs.ID).Save(&graph); dt.Error != nil {
 		tx.Rollback()
@@ -195,16 +150,20 @@ func DashboardGraphUpdate(c *gin.Context) {
 }
 
 type APIDashboardGraphGetOuput struct {
-	GraphID    int64    `json:"graph_id" form:"graph_id"`
-	Title      string   `json:"title" form:"title"`
-	ScreenId   int64    `json:"screen_id" form:"screen_id"`
-	Endpoints  []string `json:"endpoints" form:"endpoints"`
-	Counters   []string `json:"counters" form:"counters"`
-	TimeSpan   int64    `json:"timespan" form:"timespan"`
-	GraphType  string   `json:"graph_type" form:"graph_type"`
-	Method     string   `json:"method" form:"method"`
-	Position   int64    `json:"position" form:"position"`
-	FalconTags string   `json:"falcon_tags" form:"falcon_tags"`
+	GraphID      int64    `json:"graph_id" form:"graph_id"`
+	Title        string   `json:"title" form:"title"`
+	ScreenId     int64    `json:"screen_id" form:"screen_id"`
+	Endpoints    []string `json:"endpoints" form:"endpoints"`
+	Counters     []string `json:"counters" form:"counters"`
+	TimeSpan     int64    `json:"timespan" form:"timespan"`
+	GraphType    string   `json:"graph_type" form:"graph_type"`
+	Method       string   `json:"method" form:"method"`
+	Position     int64    `json:"position" form:"position"`
+	FalconTags   string   `json:"falcon_tags" form:"falcon_tags"`
+	TimeRange    string   `json:"time_range" form:"time_range"`
+	YScale       string   `json:"y_scale" form:"y_scale"`
+	SortBy       string   `json:"sort_by" form:"sort_by"`
+	SampleMethod string   `json:"sample_method" form:"sample_method"`
 }
 
 func DashboardGraphGet(c *gin.Context) {
@@ -230,16 +189,20 @@ func buildGraphGetOutput(graph m.DashboardGraph) APIDashboardGraphGetOuput {
 	es := strings.Split(graph.Hosts, TMP_GRAPH_FILED_DELIMITER)
 	cs := strings.Split(graph.Counters, TMP_GRAPH_FILED_DELIMITER)
 	return APIDashboardGraphGetOuput{
-		GraphID:    graph.ID,
-		Title:      graph.Title,
-		Endpoints:  es,
-		Counters:   cs,
-		ScreenId:   graph.ScreenId,
-		GraphType:  graph.GraphType,
-		TimeSpan:   graph.TimeSpan,
-		Method:     graph.Method,
-		Position:   graph.Position,
-		FalconTags: graph.FalconTags,
+		GraphID:      graph.ID,
+		Title:        graph.Title,
+		Endpoints:    es,
+		Counters:     cs,
+		ScreenId:     graph.ScreenId,
+		GraphType:    graph.GraphType,
+		TimeSpan:     graph.TimeSpan,
+		Method:       graph.Method,
+		Position:     graph.Position,
+		FalconTags:   graph.FalconTags,
+		TimeRange:    graph.TimeRange,
+		YScale:       graph.YScale,
+		SampleMethod: graph.SampleMethod,
+		SortBy:       graph.SortBy,
 	}
 }
 
@@ -283,23 +246,9 @@ func DashboardGraphGetsByScreenID(c *gin.Context) {
 		return
 	}
 
-	ret := []map[string]interface{}{}
+	ret := make([]APIDashboardGraphGetOuput, len(graphs))
 	for _, graph := range graphs {
-		es := strings.Split(graph.Hosts, TMP_GRAPH_FILED_DELIMITER)
-		cs := strings.Split(graph.Counters, TMP_GRAPH_FILED_DELIMITER)
-
-		r := map[string]interface{}{
-			"graph_id":    graph.ID,
-			"title":       graph.Title,
-			"endpoints":   es,
-			"counters":    cs,
-			"screen_id":   graph.ScreenId,
-			"graph_type":  graph.GraphType,
-			"timespan":    graph.TimeSpan,
-			"method":      graph.Method,
-			"position":    graph.Position,
-			"falcon_tags": graph.FalconTags,
-		}
+		r := buildGraphGetOutput(graph)
 		ret = append(ret, r)
 	}
 
@@ -332,16 +281,20 @@ func DashboardGraphClone(c *gin.Context) {
 	}
 	tx := db.Dashboard.Begin()
 	newGraph := m.DashboardGraph{
-		Title:      inputs.Name,
-		Hosts:      originalGraph.Hosts,
-		Counters:   originalGraph.Counters,
-		ScreenId:   originalGraph.ScreenId,
-		TimeSpan:   originalGraph.TimeSpan,
-		GraphType:  originalGraph.GraphType,
-		Method:     originalGraph.Method,
-		Position:   originalGraph.Position,
-		FalconTags: originalGraph.FalconTags,
-		Creator:    user.Name,
+		Title:        inputs.Name,
+		Hosts:        originalGraph.Hosts,
+		Counters:     originalGraph.Counters,
+		ScreenId:     originalGraph.ScreenId,
+		TimeSpan:     originalGraph.TimeSpan,
+		GraphType:    originalGraph.GraphType,
+		Method:       originalGraph.Method,
+		Position:     originalGraph.Position,
+		FalconTags:   originalGraph.FalconTags,
+		Creator:      user.Name,
+		SampleMethod: originalGraph.SampleMethod,
+		TimeRange:    originalGraph.TimeRange,
+		SortBy:       originalGraph.SortBy,
+		YScale:       originalGraph.YScale,
 	}
 	if dt := tx.Model(&newGraph).Save(&newGraph); dt.Error != nil {
 		tx.Rollback()
@@ -349,5 +302,5 @@ func DashboardGraphClone(c *gin.Context) {
 		return
 	}
 	tx.Commit()
-	h.JSONR(c, newGraph)
+	h.JSONR(c, buildGraphGetOutput(newGraph))
 }

--- a/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_controller.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	h "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/helper"
 	m "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/model/dashboard"
@@ -306,11 +307,12 @@ func DashboardGraphGetsByScreenID(c *gin.Context) {
 }
 
 type APIDashboardGraphCloneInputs struct {
-	ID int64 `json:"id" form:"id" binding:"required"`
+	ID   int64  `json:"id" form:"id" binding:"required"`
+	Name string `json:"name" form:"name"`
 }
 
 func DashboardGraphClone(c *gin.Context) {
-	inputs := APIDashboardGraphCloneInputs{}
+	inputs := APIDashboardGraphCloneInputs{Name: "NaN"}
 	if err := c.Bind(&inputs); err != nil {
 		h.JSONR(c, badstatus, fmt.Errorf("binding inputs got error:%s", err.Error()))
 		return
@@ -325,9 +327,12 @@ func DashboardGraphClone(c *gin.Context) {
 		h.JSONR(c, badstatus, fmt.Errorf("find graph with id: %d, got error:%s", inputs.ID, dt.Error.Error()))
 		return
 	}
+	if inputs.Name == "NaN" {
+		inputs.Name = fmt.Sprintf("%s_copy_%d", originalGraph.Title, time.Now().Unix())
+	}
 	tx := db.Dashboard.Begin()
 	newGraph := m.DashboardGraph{
-		Title:      fmt.Sprintf("%s_copy", originalGraph.Title),
+		Title:      inputs.Name,
 		Hosts:      originalGraph.Hosts,
 		Counters:   originalGraph.Counters,
 		ScreenId:   originalGraph.ScreenId,

--- a/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_controller.go
@@ -69,7 +69,7 @@ func DashboardGraphCreate(c *gin.Context) {
 	}
 	dt.Commit()
 	db.Dashboard.Model(&screen).Where("id = ?", screen.ID).Scan(&screen)
-	h.JSONR(c, map[string]interface{}{"graph": buildGraphGetOutput(d), "screen_id": screen.ID, "screen_name": screen.Name})
+	h.JSONR(c, map[string]interface{}{"graph": BuildGraphGetOutput(d), "screen_id": screen.ID, "screen_name": screen.Name})
 }
 
 func DashboardGraphUpdate(c *gin.Context) {
@@ -146,7 +146,7 @@ func DashboardGraphUpdate(c *gin.Context) {
 		return
 	}
 	tx.Commit()
-	h.JSONR(c, buildGraphGetOutput(graph))
+	h.JSONR(c, BuildGraphGetOutput(graph))
 }
 
 type APIDashboardGraphGetOuput struct {
@@ -181,11 +181,11 @@ func DashboardGraphGet(c *gin.Context) {
 		return
 	}
 
-	h.JSONR(c, buildGraphGetOutput(graph))
+	h.JSONR(c, BuildGraphGetOutput(graph))
 
 }
 
-func buildGraphGetOutput(graph m.DashboardGraph) APIDashboardGraphGetOuput {
+func BuildGraphGetOutput(graph m.DashboardGraph) APIDashboardGraphGetOuput {
 	es := strings.Split(graph.Hosts, TMP_GRAPH_FILED_DELIMITER)
 	cs := strings.Split(graph.Counters, TMP_GRAPH_FILED_DELIMITER)
 	return APIDashboardGraphGetOuput{
@@ -248,7 +248,7 @@ func DashboardGraphGetsByScreenID(c *gin.Context) {
 
 	ret := make([]APIDashboardGraphGetOuput, len(graphs))
 	for _, graph := range graphs {
-		r := buildGraphGetOutput(graph)
+		r := BuildGraphGetOutput(graph)
 		ret = append(ret, r)
 	}
 
@@ -302,5 +302,5 @@ func DashboardGraphClone(c *gin.Context) {
 		return
 	}
 	tx.Commit()
-	h.JSONR(c, buildGraphGetOutput(newGraph))
+	h.JSONR(c, BuildGraphGetOutput(newGraph))
 }

--- a/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_owl_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_owl_controller.go
@@ -77,5 +77,5 @@ func GraphCreateReqDataWithNewScreen(c *gin.Context) {
 	}
 	dt.Commit()
 
-	h.JSONR(c, map[string]interface{}{"graph": buildGraphGetOutput(d), "screen_id": d.ScreenId, "screen_name": inputs.ScreenName})
+	h.JSONR(c, map[string]interface{}{"graph": BuildGraphGetOutput(d), "screen_id": d.ScreenId, "screen_name": inputs.ScreenName})
 }

--- a/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_owl_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_graph/dashboard_graph_owl_controller.go
@@ -1,7 +1,6 @@
 package dashboard_graph
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -10,43 +9,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type APIGraphCreateReqDataWithNewScreenInputs struct {
-	ScreenName string   `json:"screen_name" form:"screen_name" binding:"required"`
-	Title      string   `json:"title" form:"title" binding:"required"`
-	Endpoints  []string `json:"endpoints" form:"endpoints" binding:"required"`
-	Counters   []string `json:"counters" form:"counters" binding:"required"`
-	TimeSpan   int64    `json:"timespan" form:"timespan"`
-	GraphType  string   `json:"graph_type" form:"graph_type" binding:"required"`
-	Method     string   `json:"method" form:"method"`
-	Position   int64    `json:"position" form:"position"`
-	FalconTags string   `json:"falcon_tags" form:"falcon_tags"`
-}
-
-func (mine APIGraphCreateReqDataWithNewScreenInputs) Check() (err error) {
-	sc := m.DashboardScreen{Name: mine.ScreenName}
-	// check screen_id
-	if sc.ExistName() {
-		err = fmt.Errorf("screen name:%v already existing", mine.ScreenName)
-		return
-	}
-
-	if mine.TimeSpan%60 != 0 {
-		err = fmt.Errorf("value of timespan is not vaild: %v", mine.TimeSpan)
-		return
-	}
-
-	if mine.GraphType != "h" && mine.GraphType != "k" && mine.GraphType != "a" {
-		err = fmt.Errorf("value of graph_type only accpet 'k' or 'h' or 'a', you typed: %v", mine.GraphType)
-		return
-	}
-	return
-}
-
 func GraphCreateReqDataWithNewScreen(c *gin.Context) {
-	inputs := APIGraphCreateReqDataWithNewScreenInputs{}
 	// set default value
-	inputs.TimeSpan = 3600
-	inputs.GraphType = "h"
+	inputs := APIGraphCreateReqDataWithNewScreenInputs{
+		TimeSpan:     3600,
+		GraphType:    "h",
+		TimeRange:    "3h",
+		SortBy:       "a-z",
+		SampleMethod: "AVERAGE",
+	}
 	if err := c.Bind(&inputs); err != nil {
 		h.JSONR(c, badstatus, err)
 		return
@@ -84,15 +55,19 @@ func GraphCreateReqDataWithNewScreen(c *gin.Context) {
 	}
 
 	d := m.DashboardGraph{
-		Title:     inputs.Title,
-		Hosts:     esString,
-		Counters:  csString,
-		ScreenId:  sc.ID,
-		TimeSpan:  inputs.TimeSpan,
-		GraphType: inputs.GraphType,
-		Method:    inputs.Method,
-		Position:  inputs.Position,
-		Creator:   user.Name,
+		Title:        inputs.Title,
+		Hosts:        esString,
+		Counters:     csString,
+		ScreenId:     sc.ID,
+		TimeSpan:     inputs.TimeSpan,
+		GraphType:    inputs.GraphType,
+		Method:       inputs.Method,
+		Position:     inputs.Position,
+		Creator:      user.Name,
+		TimeRange:    inputs.TimeRange,
+		SortBy:       inputs.SortBy,
+		SampleMethod: inputs.SampleMethod,
+		YScale:       inputs.YScale,
 	}
 	dt = dt.Save(&d)
 	if dt.Error != nil {
@@ -100,16 +75,7 @@ func GraphCreateReqDataWithNewScreen(c *gin.Context) {
 		h.JSONR(c, badstatus, dt.Error)
 		return
 	}
-
-	var lid []int
-	dt = dt.Table(d.TableName()).Raw("select LAST_INSERT_ID() as id").Pluck("id", &lid)
-	if dt.Error != nil {
-		dt.Rollback()
-		h.JSONR(c, badstatus, dt.Error)
-		return
-	}
 	dt.Commit()
-	aid := lid[0]
 
-	h.JSONR(c, map[string]interface{}{"id": aid, "screen_id": d.ScreenId, "screen_name": inputs.ScreenName})
+	h.JSONR(c, map[string]interface{}{"graph": buildGraphGetOutput(d), "screen_id": d.ScreenId, "screen_name": inputs.ScreenName})
 }

--- a/modules/f2e-api/app/controller/dashboard_graph/dashboard_structs.go
+++ b/modules/f2e-api/app/controller/dashboard_graph/dashboard_structs.go
@@ -1,0 +1,188 @@
+package dashboard_graph
+
+import (
+	"fmt"
+	"regexp"
+
+	m "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/model/dashboard"
+)
+
+type GraphObj struct {
+	Title        string
+	Endpoints    []string
+	Counters     []string
+	TimeSpan     int64
+	GraphType    string
+	Method       string
+	Position     int64
+	FalconTags   string
+	TimeRange    string
+	YScale       string
+	SortBy       string
+	SampleMethod string
+}
+
+func (mine GraphObj) CustomCheck() (err error) {
+
+	if mine.Method != "" && mine.Method != "NULL" && mine.Method != "sum" {
+		err = fmt.Errorf("method not vaild: %v, only accept 'sum' or 'NULL'", mine.Method)
+		return
+	}
+
+	if mine.GraphType != "h" && mine.GraphType != "k" && mine.GraphType != "a" {
+		err = fmt.Errorf("value of graph_type only accept 'k' or 'h' or 'a', you typed: %v", mine.GraphType)
+		return
+	}
+
+	if mine.SortBy != "" && mine.SortBy != "a-z" && mine.SortBy != "z-a" {
+		err = fmt.Errorf("sort_by only accept 'a-z' or 'z-a', you typed: %v", mine.GraphType)
+		return
+	}
+
+	// only accpet
+	// ex. 1495508389,1496372791
+	// ex. 3d
+	if mine.TimeRange != "" {
+		if match, _ := regexp.MatchString("^((\\d{8}\\d{1,5},\\d{8}\\d{1,5})|(\\d+(h|d|w|m|y)))$", mine.TimeRange); !match {
+			err = fmt.Errorf(`you typed: %v, time_range only accept ex. "1495508389,1496372791" or "3d" [h,d,w,m,y]`, mine.TimeRange)
+			return
+		}
+	}
+
+	if mine.YScale != "" {
+		// [\d\.]+
+		// k m g t
+		if match, _ := regexp.MatchString("^(\\d+(k|m|g|t)|[\\d\\.]+)(,(\\d+(k|m|g|t)|[\\d\\.]+))?$", mine.YScale); !match {
+			err = fmt.Errorf(`y_scale value: '%v' not vaild, please check api document`, mine.YScale)
+			return
+		}
+	}
+
+	if mine.SampleMethod != "" {
+		flag := false
+		slist := []string{"AVERAGE", "MAX", "MIN"}
+		for _, s := range slist {
+			flag = mine.SampleMethod == s
+			if flag {
+				break
+			}
+		}
+		if !flag {
+			err = fmt.Errorf(`sample_method value: '%v' not vaild, only accept: "AVERAGE" or "MAX" or "MIN"`, mine.SampleMethod)
+			return
+		}
+	}
+	return
+}
+
+// Inputs struct for GraphCreateReqDataWithNewScreen
+type APIGraphCreateReqDataWithNewScreenInputs struct {
+	ScreenName   string   `json:"screen_name" form:"screen_name" binding:"required"`
+	Title        string   `json:"title" form:"title" binding:"required"`
+	Endpoints    []string `json:"endpoints" form:"endpoints" binding:"required"`
+	Counters     []string `json:"counters" form:"counters" binding:"required"`
+	TimeSpan     int64    `json:"timespan" form:"timespan"`
+	GraphType    string   `json:"graph_type" form:"graph_type" binding:"required"`
+	Method       string   `json:"method" form:"method"`
+	Position     int64    `json:"position" form:"position"`
+	FalconTags   string   `json:"falcon_tags" form:"falcon_tags"`
+	TimeRange    string   `json:"time_range" form:"time_range"`
+	YScale       string   `json:"y_scale" form:"y_scale"`
+	SortBy       string   `json:"sort_by" form:"sort_by"`
+	SampleMethod string   `json:"sample_method" form:"sample_method"`
+}
+
+func (mine APIGraphCreateReqDataWithNewScreenInputs) Check() (err error) {
+	sc := m.DashboardScreen{Name: mine.ScreenName}
+	// check screen_id
+	if sc.ExistName() {
+		err = fmt.Errorf("screen name:%v already existing", mine.ScreenName)
+		return
+	}
+
+	graphobj := GraphObj{
+		GraphType:    mine.GraphType,
+		SortBy:       mine.SortBy,
+		TimeRange:    mine.TimeRange,
+		YScale:       mine.YScale,
+		SampleMethod: mine.SampleMethod,
+		Method:       mine.Method,
+	}
+	err = graphobj.CustomCheck()
+	return
+}
+
+// Inputs struct for DashboardGraphCreate
+type APIGraphCreateReqData struct {
+	ScreenId     int64    `json:"screen_id" form:"screen_id" binding:"required"`
+	Title        string   `json:"title" form:"title" binding:"required"`
+	Endpoints    []string `json:"endpoints" form:"endpoints" binding:"required"`
+	Counters     []string `json:"counters" form:"counters" binding:"required"`
+	TimeSpan     int64    `json:"timespan" form:"timespan"`
+	GraphType    string   `json:"graph_type" form:"graph_type" binding:"required"`
+	Method       string   `json:"method" form:"method"`
+	Position     int64    `json:"position" form:"position"`
+	FalconTags   string   `json:"falcon_tags" form:"falcon_tags"`
+	TimeRange    string   `json:"time_range" form:"time_range" binding:"required"`
+	YScale       string   `json:"y_scale" form:"y_scale"`
+	SortBy       string   `json:"sort_by" form:"sort_by"`
+	SampleMethod string   `json:"sample_method" form:"sample_method"`
+}
+
+func (mine APIGraphCreateReqData) Check() (err error) {
+	sc := m.DashboardScreen{ID: mine.ScreenId}
+	// check screen_id
+	if !sc.Exist() {
+		err = fmt.Errorf("screen id:%v is not existing", mine.ScreenId)
+		return
+	}
+
+	graphobj := GraphObj{
+		TimeSpan:     mine.TimeSpan,
+		GraphType:    mine.GraphType,
+		SortBy:       mine.SortBy,
+		TimeRange:    mine.TimeRange,
+		YScale:       mine.YScale,
+		SampleMethod: mine.SampleMethod,
+	}
+	err = graphobj.CustomCheck()
+	return
+}
+
+// Inputs struct for DashboardGraphUpdate
+type APIGraphUpdateReqData struct {
+	ID           int64    `json:"id" form:"id" binding:"required"`
+	ScreenId     int64    `json:"screen_id" form:"screen_id"`
+	Title        string   `json:"title" form:"title"`
+	Endpoints    []string `json:"endpoints" form:"endpoints"`
+	Counters     []string `json:"counters" form:"counters"`
+	TimeSpan     int64    `json:"timespan" form:"timespan"`
+	GraphType    string   `json:"graph_type" form:"graph_type"`
+	Method       string   `json:"method" form:"method"`
+	Position     int64    `json:"position" form:"position"`
+	FalconTags   string   `json:"falcon_tags" form:"falcon_tags"`
+	TimeRange    string   `json:"time_range" form:"time_range"`
+	YScale       string   `json:"y_scale" form:"y_scale"`
+	SortBy       string   `json:"sort_by" form:"sort_by"`
+	SampleMethod string   `json:"sample_method" form:"sample_method"`
+}
+
+func (mine APIGraphUpdateReqData) Check() (err error) {
+	sc := m.DashboardScreen{ID: mine.ScreenId}
+	// check screen_id
+	if mine.ScreenId != 0 && !sc.Exist() {
+		err = fmt.Errorf("screen id:%v is not existing", mine.ScreenId)
+		return
+	}
+
+	graphobj := GraphObj{
+		TimeSpan:     mine.TimeSpan,
+		GraphType:    mine.GraphType,
+		SortBy:       mine.SortBy,
+		TimeRange:    mine.TimeRange,
+		YScale:       mine.YScale,
+		SampleMethod: mine.SampleMethod,
+	}
+	err = graphobj.CustomCheck()
+	return
+}

--- a/modules/f2e-api/app/controller/dashboard_screen/dashboard_screen_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_screen/dashboard_screen_controller.go
@@ -127,7 +127,8 @@ func ScreenGetsAll(c *gin.Context) {
 	totallCount := 0
 	dt := db.Dashboard.Model(&screens)
 	if inputs.KeyWord != "" {
-		dt = dt.Where("name like ?", "%"+inputs.KeyWord+"%")
+		filterKeyForSql := "%" + inputs.KeyWord + "%"
+		dt = dt.Where("name like ? OR creator like ?", filterKeyForSql, filterKeyForSql)
 	}
 	if inputs.Page <= 0 {
 		if inputs.Order {

--- a/modules/f2e-api/app/controller/dashboard_screen/dashboard_screen_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_screen/dashboard_screen_controller.go
@@ -250,7 +250,7 @@ func ScreenUpdate(c *gin.Context) {
 		return
 	}
 
-	h.JSONR(c, "ok")
+	h.JSONR(c, newData)
 }
 
 // For clone screen by id

--- a/modules/f2e-api/app/controller/dashboard_screen/dashboard_screen_controller.go
+++ b/modules/f2e-api/app/controller/dashboard_screen/dashboard_screen_controller.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 
+	dgraph "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/controller/dashboard_graph"
 	h "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/helper"
 	m "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/model/dashboard"
 	"github.com/gin-gonic/gin"
@@ -76,22 +76,9 @@ func ScreenGet(c *gin.Context) {
 
 	graphsTmp := []m.DashboardGraph{}
 	db.Dashboard.Model(&graphsTmp).Where("screen_id = ?", screen.ID).Scan(&graphsTmp)
-	graphs := []map[string]interface{}{}
-	for _, graph := range graphsTmp {
-		es := strings.Split(graph.Hosts, TMP_GRAPH_FILED_DELIMITER)
-		cs := strings.Split(graph.Counters, TMP_GRAPH_FILED_DELIMITER)
-		graphs = append(graphs, map[string]interface{}{
-			"graph_id":    graph.ID,
-			"title":       graph.Title,
-			"endpoints":   es,
-			"counters":    cs,
-			"screen_id":   graph.ScreenId,
-			"graph_type":  graph.GraphType,
-			"timespan":    graph.TimeSpan,
-			"method":      graph.Method,
-			"position":    graph.Position,
-			"falcon_tags": graph.FalconTags,
-		})
+	graphs := make([]dgraph.APIDashboardGraphGetOuput, len(graphsTmp))
+	for indx, graph := range graphsTmp {
+		graphs[indx] = dgraph.BuildGraphGetOutput(graph)
 	}
 	h.JSONR(c, map[string]interface{}{
 		"scren":  screen,

--- a/modules/f2e-api/app/model/dashboard/dashboard_graph.go
+++ b/modules/f2e-api/app/model/dashboard/dashboard_graph.go
@@ -1,32 +1,41 @@
 package dashboard
 
-// +-------------+------------------+------+-----+---------+----------------+
-// | Field       | Type             | Null | Key | Default | Extra          |
-// +-------------+------------------+------+-----+---------+----------------+
-// | id          | int(11) unsigned | NO   | PRI | NULL    | auto_increment |
-// | title       | char(128)        | NO   |     | NULL    |                |
-// | hosts       | varchar(10240)   | NO   |     |         |                |
-// | counters    | varchar(1024)    | NO   |     |         |                |
-// | screen_id   | int(11) unsigned | NO   | MUL | NULL    |                |
-// | timespan    | int(11) unsigned | NO   |     | 3600    |                |
-// | graph_type  | char(2)          | NO   |     | h       |                |
-// | method      | char(8)          | YES  |     |         |                |
-// | position    | int(11) unsigned | NO   |     | 0       |                |
-// | falcon_tags | varchar(512)     | NO   |     |         |                |
-// +-------------+------------------+------+-----+---------+----------------+
+// +---------------+------------------+------+-----+---------+----------------+
+// | Field         | Type             | Null | Key | Default | Extra          |
+// +---------------+------------------+------+-----+---------+----------------+
+// | id            | int(11) unsigned | NO   | PRI | NULL    | auto_increment |
+// | title         | char(128)        | NO   |     | NULL    |                |
+// | hosts         | varchar(10240)   | NO   |     |         |                |
+// | counters      | varchar(1024)    | NO   |     |         |                |
+// | screen_id     | int(11) unsigned | NO   | MUL | NULL    |                |
+// | timespan      | int(11) unsigned | NO   |     | 3600    |                |
+// | graph_type    | char(2)          | NO   |     | h       |                |
+// | method        | char(8)          | YES  |     |         |                |
+// | position      | int(11) unsigned | NO   |     | 0       |                |
+// | falcon_tags   | varchar(512)     | NO   |     |         |                |
+// | creator       | varchar(50)      | YES  |     | root    |                |
+// | time_range    | varchar(50)      | YES  |     | 3h      |                |
+// | y_scale       | varchar(50)      | YES  |     | NULL    |                |
+// | sort_by       | varchar(30)      | YES  |     | a-z     |                |
+// | sample_method | varchar(20)      | YES  |     | AVERAGE |                |
+// +---------------+------------------+------+-----+---------+----------------+
 
 type DashboardGraph struct {
-	ID         int64  `json:"id" gorm:"column:id"`
-	Title      string `json:"title" gorm:"column:title"`
-	Hosts      string `json:"hosts" gorm:"column:hosts"`
-	Counters   string `json:"counters" gorm:"column:counters"`
-	ScreenId   int64  `json:"screen_id" gorm:"column:screen_id"`
-	TimeSpan   int64  `json:"timespan" gorm:"column:timespan"`
-	GraphType  string `json:"graph_type" gorm:"column:graph_type"`
-	Method     string `json:"method" gorm:"column:method"`
-	Position   int64  `json:"position" gorm:"column:position"`
-	FalconTags string `json:"falcon_tags" gorm:"column:falcon_tags"`
-	Creator    string `json:"creator" gorm:"column:creator"`
+	ID           int64  `json:"id" gorm:"column:id"`
+	Title        string `json:"title" gorm:"column:title"`
+	Hosts        string `json:"hosts" gorm:"column:hosts"`
+	Counters     string `json:"counters" gorm:"column:counters"`
+	ScreenId     int64  `json:"screen_id" gorm:"column:screen_id"`
+	TimeSpan     int64  `json:"timespan" gorm:"column:timespan"`
+	GraphType    string `json:"graph_type" gorm:"column:graph_type"`
+	Method       string `json:"method" gorm:"column:method"`
+	Position     int64  `json:"position" gorm:"column:position"`
+	FalconTags   string `json:"falcon_tags" gorm:"column:falcon_tags"`
+	Creator      string `json:"creator" gorm:"column:creator"`
+	TimeRange    string `json:"time_range" gorm:"column:time_range"`
+	YScale       string `json:"y_scale" gorm:"column:y_scale"`
+	SortBy       string `json:"sort_by" gorm:"column:sort_by"`
+	SampleMethod string `json:"sample_method" gorm:"column:sample_method"`
 }
 
 func (this DashboardGraph) TableName() string {

--- a/modules/f2e-api/app/model/dashboard/dashboard_screen.go
+++ b/modules/f2e-api/app/model/dashboard/dashboard_screen.go
@@ -45,7 +45,11 @@ func (mine DashboardScreen) Exist() bool {
 func (mine DashboardScreen) ExistName() bool {
 	db := con.Con()
 	rcount := 0
-	db.Dashboard.Model(&mine).Where("name = ?", mine.Name).Count(&rcount)
+	if mine.ID == 0 {
+		db.Dashboard.Model(&mine).Where("name = ?", mine.Name).Count(&rcount)
+	} else {
+		db.Dashboard.Table(mine.TableName()).Where("name = ? AND id != ?", mine.Name, mine.ID).Count(&rcount)
+	}
 	if rcount != 0 {
 		return true
 	} else {

--- a/modules/f2e-api/test/controller_test/dashboard_graph/dashboard_graph_test.go
+++ b/modules/f2e-api/test/controller_test/dashboard_graph/dashboard_graph_test.go
@@ -139,11 +139,10 @@ func TestDashboardGraphController(t *testing.T) {
 					Endpoints:  []string{"a1", "a2"},
 					Counters:   []string{"c1", "c2"},
 					ID:         int64(testGraphId),
-					TimeSpan:   int64(9999),
 					GraphType:  "a",
 					Method:     "sum",
 					Position:   int64(22),
-					ScreenId:   955,
+					ScreenId:   1247,
 					FalconTags: "a=1,b=2",
 				}
 				b, _ := json.Marshal(postb)
@@ -157,8 +156,6 @@ func TestDashboardGraphController(t *testing.T) {
 				So(convertArrInterfaceToArrString(value.Array()), ShouldResemble, postb.Endpoints)
 				value = gjson.Get(w.Body.String(), "counters")
 				So(convertArrInterfaceToArrString(value.Array()), ShouldResemble, postb.Counters)
-				value = gjson.Get(w.Body.String(), "timespan")
-				So(value.Int(), ShouldResemble, postb.TimeSpan)
 				value = gjson.Get(w.Body.String(), "graph_type")
 				So(value.String(), ShouldResemble, postb.GraphType)
 				value = gjson.Get(w.Body.String(), "method")

--- a/modules/f2e-api/test/controller_test/dashboard_graph/struct/struct_test.go
+++ b/modules/f2e-api/test/controller_test/dashboard_graph/struct/struct_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"testing"
+
+	dg "github.com/Cepave/open-falcon-backend/modules/f2e-api/app/controller/dashboard_graph"
+	"github.com/Cepave/open-falcon-backend/modules/f2e-api/config"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/spf13/viper"
+)
+
+func TestDashboardGraphCustomStruct(t *testing.T) {
+	viper.Set("services", map[string]interface{}{
+		"test":  "test123",
+		"test2": "test456",
+	})
+	viper.Set("enable_services", true)
+	viper.AddConfigPath(".")
+	viper.AddConfigPath("../../../")
+	viper.SetConfigName("cfg_test")
+	err := viper.ReadInConfig()
+	if err != nil {
+		log.Error(err.Error())
+	}
+	gin.SetMode(gin.TestMode)
+	log.SetLevel(log.DebugLevel)
+	config.InitDB(viper.GetBool("db.db_debug"))
+	Convey("test struct a", t, func() {
+		tests1 := dg.APIGraphCreateReqDataWithNewScreenInputs{
+			ScreenName: "CPU",
+			Title:      "aaa2",
+			Endpoints:  []string{"e1", "e2"},
+			Counters:   []string{"m1", "m2"},
+			TimeSpan:   3600,
+			GraphType:  "h",
+			Method:     "sum",
+			TimeRange:  "3h",
+			SortBy:     "a-z",
+		}
+		err := tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "already existing")
+		tests1.ScreenName = "aaa1"
+		tests1.GraphType = "xx"
+		err = tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "value of graph_type only accept")
+		tests1.GraphType = "h"
+		tests1.SortBy = "xx"
+		err = tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "sort_by only accept 'a-z' or 'z-a'")
+		tests1.SortBy = "z-a"
+		tests1.TimeRange = "3x"
+		err = tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "time_range only accept")
+		tests1.TimeRange = "323213,213"
+		err = tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "time_range only accept")
+		tests1.TimeRange = "3d"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.TimeRange = "1496293526,1496379923"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.YScale = "1u"
+		err = tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "not vaild")
+		tests1.YScale = "10000.1"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.YScale = "10000"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.YScale = "10000,10000"
+		err = tests1.Check()
+		tests1.YScale = "10000,1k"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.YScale = "1k"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.YScale = "1k,2k"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.YScale = "1k,20"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+		tests1.SampleMethod = "notvail"
+		err = tests1.Check()
+		So(err.Error(), ShouldContainSubstring, "not vaild, only accept")
+		tests1.SampleMethod = "MAX"
+		err = tests1.Check()
+		So(err, ShouldEqual, nil)
+	})
+}

--- a/scripts/mysql/db_schema/dashboard-db-schema.sql
+++ b/scripts/mysql/db_schema/dashboard-db-schema.sql
@@ -40,6 +40,10 @@ CREATE TABLE `dashboard_graph` (
   `position` int(11) unsigned NOT NULL DEFAULT '0',
   `falcon_tags` varchar(512) NOT NULL DEFAULT '',
   `creator` varchar(50) DEFAULT 'root',
+  `time_range` varchar(150) DEFAULT '3h',
+  `y_scale` varchar(50) DEFAULT NULL,
+  `sort_by` varchar(30) DEFAULT 'a-z',
+  `sample_method` varchar(20) DEFAULT 'AVERAGE',
   PRIMARY KEY (`id`),
   KEY `idx_sid` (`screen_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4626 DEFAULT CHARSET=utf8;

--- a/scripts/mysql/dbpatch/change-log/change-log-dashboard.yaml
+++ b/scripts/mysql/dbpatch/change-log/change-log-dashboard.yaml
@@ -8,5 +8,10 @@
         id: "masato-2",
         filename: "masato-2.sql",
         comment: "add creator field to dashboard_graph & dsahboard_screen"
+    },
+    {
+        id: "masato-3",
+        filename: "masato-3.sql",
+        comment: "add more field to dashboard_graph, let it can store more info"
     }
 ]

--- a/scripts/mysql/dbpatch/change-log/schema-dashboard/masato-3.sql
+++ b/scripts/mysql/dbpatch/change-log/schema-dashboard/masato-3.sql
@@ -1,0 +1,6 @@
+ALTER TABLE dashboard_graph
+  ADD COLUMN `time_range` varchar(50) DEFAULT '3h',
+  ADD COLUMN `y_scale` varchar(50) DEFAULT NULL,
+  ADD COLUMN `sample_method` varchar(20) DEFAULT 'AVERAGE',
+  ADD COLUMN `sort_by` varchar(30) DEFAULT 'a-z';
+


### PR DESCRIPTION
*  support set new name of copy api in dashboard_screen_clone/dashboard
*  modified db schema & model of dashboard graph
    * add fields `time_range`, `y_scale`, `sort_by`, `sample_method` in dashboard_graph table
* unique name issue of dashboard_screen
* update response data format from owl-light f2e team
* support query screen list with creator name