### PR TITLE
[OWL-1828] fix Agent auto updating feature

### DIFF
--- a/modules/agent/g/const.go
+++ b/modules/agent/g/const.go
@@ -19,8 +19,9 @@ import (
 // 5.1.10: Fix and modify builtin metrics.
 // 5.2.0: Fix agent orphan processes problem and add /v1/tail API
 // 6.0.0: Use new plugin/git repo updating mechanism.
+// 6.1.0: Add timeout mechanism on 'git fetch', 'git clone', 'git ls-remote' command
 const (
-	VERSION          = "6.0.0"
+	VERSION          = "6.1.0"
 	COLLECT_INTERVAL = time.Second
 	URL_CHECK_HEALTH = "url.check.health"
 	NET_PORT_LISTEN  = "net.port.listen"

--- a/modules/agent/plugins/update.go
+++ b/modules/agent/plugins/update.go
@@ -119,7 +119,7 @@ func UpdatePlugin(ver string, repo string) error {
 		lastPluginUpdate = time.Now().Unix()
 
 		buf.Reset()
-		cmd := exec.Command("git", "fetch")
+		cmd := exec.Command("timeout", "60s", "git", "fetch")
 		cmd.Dir = cfg.Dir
 		cmd.Stdout = &buf
 		cmd.Stderr = &buf
@@ -147,7 +147,7 @@ func UpdatePlugin(ver string, repo string) error {
 		log.Println("Begin update plugins by clone")
 		lastPluginUpdate = time.Now().Unix()
 		buf.Reset()
-		cmd := exec.Command("git", "clone", repo, file.Basename(cfg.Dir))
+		cmd := exec.Command("timeout", "200s", "git", "clone", repo, file.Basename(cfg.Dir))
 		cmd.Dir = parentDir
 		cmd.Stdout = &buf
 		cmd.Stderr = &buf
@@ -176,7 +176,7 @@ func UpdatePlugin(ver string, repo string) error {
 
 func GitLsRemote(gitRepo string, refs string) (string, error) {
 	// This function depends on git command
-	if resultStr, err := sys.CmdOut("git", "ls-remote", gitRepo, refs); err != nil {
+	if resultStr, err := sys.CmdOut("timeout", "30s", "git", "ls-remote", gitRepo, refs); err != nil {
 		return "", err
 	} else {
 		// resultStr should be:


### PR DESCRIPTION
Agent 6.0.0 上線之後，發現自動更新的功能有的時候會卡住。卡住的原因是 git fetch 和 git ls-remote 沒有考慮 timeout 的問題。這一版的 Agent 對上述的 git 指令加上 timeout 的限制。