### PR TITLE
[OWL-1853] change the dependency of table boss.hosts from table grafana.idc to table boss.idcs

### DIFF
--- a/modules/query/http/cron.go
+++ b/modules/query/http/cron.go
@@ -16,10 +16,17 @@ import (
 	cmodel "github.com/Cepave/open-falcon-backend/common/model"
 	"github.com/Cepave/open-falcon-backend/modules/query/g"
 	"github.com/Cepave/open-falcon-backend/modules/query/graph"
-	log "github.com/sirupsen/logrus"
 	"github.com/astaxie/beego/orm"
 	"github.com/jasonlvhit/gocron"
+	log "github.com/sirupsen/logrus"
 )
+
+type IDCMapItem struct {
+	Popid    int
+	Idc      string
+	Province string
+	City     string
+}
 
 type Contacts struct {
 	Id      int
@@ -121,15 +128,15 @@ func SyncHostsAndContactsTable() {
 func getIDCMap() map[string]interface{} {
 	idcMap := map[string]interface{}{}
 	o := orm.NewOrm()
-	o.Using("grafana")
-	var idcs []Idc
-	sqlcommand := "SELECT pop_id, name, province, city FROM `grafana`.`idc` ORDER BY pop_id ASC"
+	o.Using("boss")
+	var idcs []IDCMapItem
+	sqlcommand := "SELECT `popid`, `idc`, `province`, `city` FROM `idcs` ORDER BY popid ASC"
 	_, err := o.Raw(sqlcommand).QueryRows(&idcs)
 	if err != nil {
 		log.Errorf(err.Error())
 	}
 	for _, idc := range idcs {
-		idcMap[strconv.Itoa(idc.Pop_id)] = idc
+		idcMap[strconv.Itoa(idc.Popid)] = idc
 	}
 	return idcMap
 }
@@ -1221,9 +1228,9 @@ func updateHostsTable(hostnames []string, hostsMap map[string]map[string]string)
 		host["ISP"] = ISP
 		idcID := host["idcID"]
 		if idc, ok := idcMap[idcID]; ok {
-			host["IDC"] = idc.(Idc).Name
-			host["province"] = idc.(Idc).Province
-			host["city"] = idc.(Idc).City
+			host["IDC"] = idc.(IDCMapItem).Idc
+			host["province"] = idc.(IDCMapItem).Province
+			host["city"] = idc.(IDCMapItem).City
 		}
 		hosts = append(hosts, host)
 	}


### PR DESCRIPTION
boss database 內的 hosts table 資料在同步時，會依賴 grafana 資料庫的 idc table，造成有時候新的機房(IDC) 資訊不同步。

其實 boss database 裡有 idcs table 。所以更改依賴的 table 即可。改成 hosts table 的資料去依賴 boss database 的 idcs table 。而且 idcs table 本來就會週期性地做更新。