### PR TITLE
[OWL-1867][common][mysqlapi] `nqm.heartbeat.count`

### DIFF
--- a/modules/mysqlapi/model/diag.go
+++ b/modules/mysqlapi/model/diag.go
@@ -19,9 +19,9 @@ package model
 //    }
 // }
 type HealthView struct {
-	Rdb  Rdb  `json:"rdb"`
-	Http Http `json:"http"`
-	Nqm  Nqm  `json:"nqm"`
+	Rdb  *Rdb  `json:"rdb"`
+	Http *Http `json:"http"`
+	Nqm  *Nqm  `json:"nqm"`
 }
 
 type Rdb struct {
@@ -36,7 +36,7 @@ type Http struct {
 }
 
 type Nqm struct {
-	Heartbeat Heartbeat `json:"heartbeat"`
+	Heartbeat *Heartbeat `json:"heartbeat"`
 }
 
 type Heartbeat struct {

--- a/modules/mysqlapi/model/diag.go
+++ b/modules/mysqlapi/model/diag.go
@@ -1,0 +1,46 @@
+package model
+
+// HealthView is the model for responsed JSON data in ``/health`
+// example:
+// {
+//    "rdb":{
+//       "dsn":"DSN....",
+//       "open_connections":10,
+//       "ping_result":0,
+//       "ping_message":""
+//    },
+//    "http":{
+//       "listening":":6040"
+//    },
+//    "nqm":{
+//       "heartbeat":{
+//          "count":21387
+//       }
+//    }
+// }
+type HealthView struct {
+	Rdb  Rdb  `json:"rdb"`
+	Http Http `json:"http"`
+	Nqm  Nqm  `json:"nqm"`
+}
+
+type Rdb struct {
+	Dsn             string `json:"dsn"`
+	OpenConnections int    `json:"open_connections"`
+	PingResult      int    `json:"ping_result"`
+	PingMessage     string `json:"ping_message"`
+}
+
+type Http struct {
+	Listening string `json:"listening"`
+}
+
+type Nqm struct {
+	Heartbeat Heartbeat `json:"heartbeat"`
+}
+
+type Heartbeat struct {
+	Count uint64 `json:"count"`
+}
+
+// :~)

--- a/modules/mysqlapi/rdb/diag.go
+++ b/modules/mysqlapi/rdb/diag.go
@@ -1,20 +1,15 @@
-package diag
+package rdb
 
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/Cepave/open-falcon-backend/modules/mysqlapi/model"
 	"github.com/go-sql-driver/mysql"
 )
 
-type RdbDiagnosis struct {
-	Dsn             string `json:"dsn"`
-	OpenConnections int    `json:"open_connections"`
-	PingResult      int    `json:"ping_result"`
-	PingMessage     string `json:"ping_message"`
-}
-
 // Performs the diagnosis to RDB
-func DiagnoseRdb(dsn string, db *sql.DB) *RdbDiagnosis {
+func DiagnoseRdb(dsn string, db *sql.DB) *model.Rdb {
 	var v int
 	err := db.QueryRow("SELECT 0 FROM DUAL").Scan(&v)
 
@@ -25,7 +20,7 @@ func DiagnoseRdb(dsn string, db *sql.DB) *RdbDiagnosis {
 		pingMessage = err.Error()
 	}
 
-	return &RdbDiagnosis{
+	return &model.Rdb{
 		Dsn:             hidePasswordOfDsn(dsn),
 		OpenConnections: db.Stats().OpenConnections,
 		PingResult:      pingResult,

--- a/modules/mysqlapi/restful/diag.go
+++ b/modules/mysqlapi/restful/diag.go
@@ -13,17 +13,12 @@ func health() mvc.OutputBody {
 		rdb.DbFacade.SqlDb,
 	)
 	resp := &model.HealthView{
-		Rdb: model.Rdb{
-			Dsn:             diagRdb.Dsn,
-			OpenConnections: diagRdb.OpenConnections,
-			PingResult:      diagRdb.PingResult,
-			PingMessage:     diagRdb.PingMessage,
-		},
-		Http: model.Http{
+		Rdb: diagRdb,
+		Http: &model.Http{
 			Listening: GinConfig.GetAddress(),
 		},
-		Nqm: model.Nqm{
-			Heartbeat: model.Heartbeat{
+		Nqm: &model.Nqm{
+			Heartbeat: &model.Heartbeat{
 				Count: service.NqmQueue.ConsumedCount(),
 			},
 		},

--- a/modules/mysqlapi/restful/diag.go
+++ b/modules/mysqlapi/restful/diag.go
@@ -1,26 +1,33 @@
 package restful
 
 import (
-	"net/http"
-
-	"github.com/Cepave/open-falcon-backend/common/diag"
+	"github.com/Cepave/open-falcon-backend/common/gin/mvc"
+	"github.com/Cepave/open-falcon-backend/modules/mysqlapi/model"
 	"github.com/Cepave/open-falcon-backend/modules/mysqlapi/rdb"
-	gin "github.com/gin-gonic/gin"
-	json "gopkg.in/bitly/go-simplejson.v0"
+	"github.com/Cepave/open-falcon-backend/modules/mysqlapi/service"
 )
 
-func health(context *gin.Context) {
-	diagRdb := diag.DiagnoseRdb(
+func health() mvc.OutputBody {
+	diagRdb := rdb.DiagnoseRdb(
 		rdb.DbConfig.Dsn,
 		rdb.DbFacade.SqlDb,
 	)
+	resp := &model.HealthView{
+		Rdb: model.Rdb{
+			Dsn:             diagRdb.Dsn,
+			OpenConnections: diagRdb.OpenConnections,
+			PingResult:      diagRdb.PingResult,
+			PingMessage:     diagRdb.PingMessage,
+		},
+		Http: model.Http{
+			Listening: GinConfig.GetAddress(),
+		},
+		Nqm: model.Nqm{
+			Heartbeat: model.Heartbeat{
+				Count: service.NqmQueue.ConsumedCount(),
+			},
+		},
+	}
 
-	jsonResp := json.New()
-	jsonResp.Set("rdb", diagRdb)
-
-	jsonHttp := json.New()
-	jsonHttp.Set("listening", GinConfig.GetAddress())
-	jsonResp.Set("http", jsonHttp)
-
-	context.JSON(http.StatusOK, jsonResp)
+	return mvc.JsonOutputBody(resp)
 }

--- a/modules/mysqlapi/restful/diag_it_test.go
+++ b/modules/mysqlapi/restful/diag_it_test.go
@@ -1,0 +1,24 @@
+package restful
+
+import (
+	"net/http"
+
+	json "github.com/Cepave/open-falcon-backend/common/json"
+	ogko "github.com/Cepave/open-falcon-backend/common/testing/ginkgo"
+	testingHttp "github.com/Cepave/open-falcon-backend/common/testing/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test /health", ginkgoDb.NeedDb(func() {
+	It("returns the JSON data", func() {
+		resp := testingHttp.NewResponseResultBySling(
+			httpClientConfig.NewSlingByBase().
+				Get("health"),
+		)
+		jsonBody := resp.GetBodyAsJson()
+		GinkgoT().Logf("[Mysql API Module Response] JSON Result:\n%s", json.MarshalPrettyJSON(jsonBody))
+		Expect(resp).To(ogko.MatchHttpStatus(http.StatusOK))
+	})
+}))

--- a/modules/mysqlapi/restful/package.go
+++ b/modules/mysqlapi/restful/package.go
@@ -84,5 +84,5 @@ func initApi() {
 
 	v1.POST("/agent/heartbeat", mvcBuilder.BuildHandler(falconAgentHeartbeat))
 
-	router.GET("/health", health)
+	router.GET("/health", mvcBuilder.BuildHandler(health))
 }


### PR DESCRIPTION
New field `nqm.heartbeat.count` in the responsed JSON data is added.
In this PR, the code is moved from `common/` to `modules/rdb/mysqlapi/`.
This commit also rewrites the struct for marshaling JSON data and uses
the `mvc` handler by the way.