### PR TITLE
[OWL-1621] Stress test of heartbeat requests

### DIFF
--- a/modules/hbs/rpc/agent_stress_test.go
+++ b/modules/hbs/rpc/agent_stress_test.go
@@ -1,0 +1,75 @@
+package rpc
+
+import (
+	"net/rpc"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	coModel "github.com/open-falcon/common/model"
+)
+
+var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJsonRpc(func() {
+	var (
+		numberOfGoRoutines int = 20
+		pool               *agentPool
+		routines           chan bool
+
+		numberOfFakeAgent    int = 500
+		numberOfTotalRequest int = 2000
+		stepOfHeartbeat      int = 30
+	)
+
+	BeforeEach(func() {
+		pool = &agentPool{numberOfFakeAgent}
+		routines = make(chan bool, numberOfGoRoutines)
+		for i := 0; i < numberOfGoRoutines; i++ {
+			routines <- true
+		}
+	})
+
+	It("Should run without error msg", func() {
+		for i := 0; i < numberOfTotalRequest; i++ {
+			if i > 0 && (i%numberOfFakeAgent == 0) {
+				time.Sleep(time.Duration(stepOfHeartbeat) * time.Second)
+			}
+			request := pool.getNextRequest(i)
+			var resp coModel.SimpleRpcResponse
+
+			<-routines
+
+			go ginkgoJsonRpc.OpenClient(func(jsonRpcClient *rpc.Client) {
+				defer func() {
+					routines <- true
+				}()
+
+				err := jsonRpcClient.Call(
+					"Agent.ReportStatus", request, &resp,
+				)
+
+				if err != nil {
+					GinkgoT().Errorf("[%s] Has error: %v", request.AgentVersion, err)
+				} else {
+					GinkgoT().Logf("[%s/%d] Success.", request.AgentVersion, numberOfTotalRequest)
+				}
+			})
+		}
+
+		for i := 0; i < numberOfGoRoutines; i++ {
+			<-routines
+		}
+	})
+}))
+
+type agentPool struct {
+	ringSize int
+}
+
+func (ap *agentPool) getNextRequest(requestNumber int) *coModel.AgentReportRequest {
+	agentIdx := strconv.Itoa(requestNumber % ap.ringSize)
+	return &coModel.AgentReportRequest{
+		Hostname:     "stress-reportstatus-" + agentIdx,
+		IP:           "127.0.0.56",
+		AgentVersion: agentIdx,
+	}
+}

--- a/modules/hbs/rpc/agent_stress_test.go
+++ b/modules/hbs/rpc/agent_stress_test.go
@@ -14,19 +14,20 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 		pool               *agentPool
 		routines           chan bool
 
-		numberOfFakeAgent int = 0
+		numberOfFakeAgents int = 0
+		numberOfSamples    int = 3
 	)
 
 	checkSkipCondition := func() {
-		if numberOfFakeAgent == 0 {
-			Skip("Number of total request is 0. See numberOfFakeAgent in code")
+		if numberOfFakeAgents == 0 {
+			Skip("Number of total request is 0. See numberOfFakeAgents in code")
 		}
 	}
 
 	BeforeEach(func() {
 		checkSkipCondition()
 
-		pool = &agentPool{numberOfFakeAgent}
+		pool = &agentPool{numberOfFakeAgents}
 		routines = make(chan bool, numberOfGoRoutines)
 		for i := 0; i < numberOfGoRoutines; i++ {
 			routines <- true
@@ -36,7 +37,7 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 	Measure("It should serve lots rpc-clients efficiently", func(b Benchmarker) {
 		checkSkipCondition()
 		b.Time("runtime", func() {
-			for i := 0; i < numberOfFakeAgent; i++ {
+			for i := 0; i < numberOfFakeAgents; i++ {
 				request := pool.getNextRequest(i)
 				var resp coModel.SimpleRpcResponse
 
@@ -54,7 +55,7 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 					if err != nil || resp.Code == 1 {
 						GinkgoT().Errorf("[%s] Has error: %v", request.AgentVersion, err)
 					} else {
-						GinkgoT().Logf("[%s/%d] Success.", request.PluginVersion, numberOfFakeAgent)
+						GinkgoT().Logf("[%s/%d] Success.", request.PluginVersion, numberOfFakeAgents)
 					}
 				})
 			}
@@ -63,7 +64,7 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 				<-routines
 			}
 		})
-	}, 3)
+	}, numberOfSamples)
 }))
 
 type agentPool struct {

--- a/modules/hbs/rpc/agent_stress_test.go
+++ b/modules/hbs/rpc/agent_stress_test.go
@@ -16,7 +16,7 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 		routines           chan bool
 
 		numberOfFakeAgent    int = 1000
-		numberOfTotalRequest int = 2000
+		numberOfTotalRequest int = 0
 		stepOfHeartbeat      int = 30
 	)
 
@@ -29,7 +29,12 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 	})
 
 	It("Should run without error msg", func() {
+		if numberOfTotalRequest == 0 {
+			Skip("Number of total request is 0. See numberOfTotalRequest in code")
+		}
+
 		for i := 0; i < numberOfTotalRequest; i++ {
+			// Simulate the heartbeat interval
 			if i > 0 && (i%numberOfFakeAgent == 0) {
 				time.Sleep(time.Duration(stepOfHeartbeat) * time.Second)
 			}

--- a/modules/hbs/rpc/agent_stress_test.go
+++ b/modules/hbs/rpc/agent_stress_test.go
@@ -11,11 +11,11 @@ import (
 
 var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJsonRpc(func() {
 	var (
-		numberOfGoRoutines int = 20
+		numberOfGoRoutines int = 50
 		pool               *agentPool
 		routines           chan bool
 
-		numberOfFakeAgent    int = 500
+		numberOfFakeAgent    int = 1000
 		numberOfTotalRequest int = 2000
 		stepOfHeartbeat      int = 30
 	)
@@ -47,10 +47,10 @@ var _ = Describe("[Stress] Test Agent.ReportStatus in HBS", ginkgoJsonRpc.NeedJs
 					"Agent.ReportStatus", request, &resp,
 				)
 
-				if err != nil {
+				if err != nil || resp.Code == 1 {
 					GinkgoT().Errorf("[%s] Has error: %v", request.AgentVersion, err)
 				} else {
-					GinkgoT().Logf("[%s/%d] Success.", request.AgentVersion, numberOfTotalRequest)
+					GinkgoT().Logf("[%s/%d] Success.", request.PluginVersion, numberOfTotalRequest)
 				}
 			})
 		}
@@ -66,10 +66,11 @@ type agentPool struct {
 }
 
 func (ap *agentPool) getNextRequest(requestNumber int) *coModel.AgentReportRequest {
-	agentIdx := strconv.Itoa(requestNumber % ap.ringSize)
+	agentIdx := strconv.Itoa((requestNumber % ap.ringSize) + 1)
 	return &coModel.AgentReportRequest{
-		Hostname:     "stress-reportstatus-" + agentIdx,
-		IP:           "127.0.0.56",
-		AgentVersion: agentIdx,
+		Hostname:      "stress-reportstatus-" + agentIdx,
+		IP:            "127.0.0.56",
+		AgentVersion:  agentIdx,
+		PluginVersion: strconv.Itoa(requestNumber + 1),
 	}
 }


### PR DESCRIPTION
A stress test that simulates agents to send heartbeat requests simultaneously.
Modify `numberOfFakeAgents` to enable the test.
