### PR TITLE
[OWL-1964] change platform ORM mapping to platforms

### DIFF
--- a/modules/f2e-api/app/model/boss/boss_model.go
+++ b/modules/f2e-api/app/model/boss/boss_model.go
@@ -5,7 +5,7 @@ import (
 )
 
 type BossHost struct {
-	Platform string `json:"platform" gorm:"column:platform"`
+	Platform string `json:"platform" gorm:"column:platforms"`
 	Province string `json:"province" gorm:"column:province"`
 	Isp      string `json:"isp"  gorm:"column:isp"`
 	Idc      string `json:"idc" gorm:"column:idc"`
@@ -20,6 +20,6 @@ func (this BossHost) TableName() string {
 func GetBossObjs() (res []BossHost) {
 	db := con.Con()
 	res = []BossHost{}
-	db.Boss.Select("platform, province, isp, idc, ip, hostname").Table("hosts").Where("exist = 1").Scan(&res)
+	db.Boss.Select("platforms, province, isp, idc, ip, hostname").Table("hosts").Where("exist = 1").Scan(&res)
 	return res
 }


### PR DESCRIPTION
原本的 ORM mapping 關系是讓  BossHost 的 platform 對應到 hosts table 的 platform 欄位。
這個修改，改成讓 BostHost 的 platform 對應到 hosts table 的 platforms 欄位。如此就可以暫時解決掉平台復用的問題。