### PR TITLE
[OWL-1956] fix update_time issue of OWL-1956

### DIFF
--- a/scripts/mysql/dbpatch/change-log/change-log-portal.yaml
+++ b/scripts/mysql/dbpatch/change-log/change-log-portal.yaml
@@ -163,3 +163,8 @@
     filename: "masato-31.sql",
     comment: "fix time fields schmea issue for alarms"
 }
+- {
+    id: "masato-32",
+    filename: "masato-32.sql",
+    comment: "fix update_time issue on OWL-1956"
+}

--- a/scripts/mysql/dbpatch/change-log/schema-portal/masato-32.sql
+++ b/scripts/mysql/dbpatch/change-log/schema-portal/masato-32.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `event_cases`
+    CHANGE `update_at` `update_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
當初database 欄位的屬性定義update就會更新時間.  但是這個欄位是拿來辨識最後告警時間的.
所以需要修復資料庫欄位屬性