### PR TITLE
[OWL-1983] 修復getEvents api返回結果問題

### DIFF
--- a/modules/f2e-api/test/api/ReadMe.md
+++ b/modules/f2e-api/test/api/ReadMe.md
@@ -15,8 +15,8 @@
   * 測試資料放置位置 `test_utils/sqltestset`
     * 如果需要增加新的測試資料請依照`t?_ooo.sql`去編號命名, 如果資料建立有先後順序關系, 請調整t之後的數字排序. 可以輔助判斷資料建立的順序
   * 資料庫的建立:
-    * 你可建立一個空的資料庫, 並手動執行過所有open-faclon需要資料的db patch. 然後運行 `cd test_utils/sqltestset && ./import_test_data.sh`
-    * 另外一個比較簡易的辦法是建立測試的docker-image, `cd #{falcon_plus}/docker && docker-compose -f init.yml up -d mysqltest `
+    * 方法一(推薦): 簡易的辦法是建立測試的docker-image. `cd ${open-falcon-backend_root_dir}/docker && docker-compose -f init.yml up -d mysqltest`
+    * 方法二: 你可建立一個空的資料庫, 並手動執行過所有open-faclon需要資料的db patch. 然後運行 `cd test_utils/sqltestset && ./import_test_data.sh`
   * 需要註意的是預設測試使用的資料庫port 為 `3307`
 4. 測試時會使用api模組資料夾下的`test_cfg`作為測試設置檔. 可以依需求修改此設置檔.
 5. 如何執行測試

--- a/modules/f2e-api/test/api/alarm/events_test.go
+++ b/modules/f2e-api/test/api/alarm/events_test.go
@@ -1,0 +1,94 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+
+	. "github.com/Cepave/open-falcon-backend/modules/f2e-api/test_utils"
+	log "github.com/sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/tidwall/gjson"
+)
+
+func TestEvents(t *testing.T) {
+	routes := SetUpGin()
+	var (
+		w        *httptest.ResponseRecorder
+		r        *http.Request
+		postb    map[string]interface{}
+		b        []byte
+		respBody string
+		rCheck   gjson.Result
+	)
+	Convey("test get events with id", t, func() {
+		// string type
+		postb = map[string]interface{}{
+			"startTime": 1466600460,
+			"endTime":   1467291660,
+			"event_id":  "s_50_6438ac68b30e2712fb8f00d894c46e21",
+			"page":      1,
+			"limit":     10,
+		}
+
+		Convey("test limit params", func() {
+			postb2 := postb
+			b, _ = json.Marshal(postb2)
+			w, r = NewTestContextWithDefaultSession("POST", "/api/v1/alarm/events", &b)
+			routes.ServeHTTP(w, r)
+			respBody = w.Body.String()
+			log.Debug(respBody)
+			rCheck = gjson.Parse(respBody)
+			So(len(rCheck.Array()), ShouldEqual, 2)
+			postb2["limit"] = 1
+			b, _ = json.Marshal(postb2)
+			w, r = NewTestContextWithDefaultSession("POST", "/api/v1/alarm/events", &b)
+			routes.ServeHTTP(w, r)
+			respBody = w.Body.String()
+			log.Debug(respBody)
+			rCheck = gjson.Parse(respBody)
+			So(len(rCheck.Array()), ShouldEqual, 1)
+		})
+		Convey("test startTime & endTime", func() {
+			postb["endTime"] = 1467637260
+			b, _ = json.Marshal(postb)
+			w, r = NewTestContextWithDefaultSession("POST", "/api/v1/alarm/events", &b)
+			routes.ServeHTTP(w, r)
+			respBody = w.Body.String()
+			log.Debug(respBody)
+			rCheck = gjson.Parse(respBody)
+			So(len(rCheck.Array()), ShouldEqual, 10)
+		})
+		Convey("test status filter", func() {
+			postb["endTime"] = 1467637260
+			postb["status"] = 1
+			b, _ = json.Marshal(postb)
+			w, r = NewTestContextWithDefaultSession("POST", "/api/v1/alarm/events", &b)
+			routes.ServeHTTP(w, r)
+			respBody = w.Body.String()
+			log.Debug(respBody)
+			rCheck = gjson.Parse(respBody)
+			So(len(rCheck.Array()), ShouldEqual, 5)
+
+			postb["status"] = 0
+			b, _ = json.Marshal(postb)
+			w, r = NewTestContextWithDefaultSession("POST", "/api/v1/alarm/events", &b)
+			routes.ServeHTTP(w, r)
+			respBody = w.Body.String()
+			log.Debug(respBody)
+			rCheck = gjson.Parse(respBody)
+			So(len(rCheck.Array()), ShouldEqual, 5)
+
+			postb["status"] = -1
+			b, _ = json.Marshal(postb)
+			w, r = NewTestContextWithDefaultSession("POST", "/api/v1/alarm/events", &b)
+			routes.ServeHTTP(w, r)
+			respBody = w.Body.String()
+			log.Debug(respBody)
+			rCheck = gjson.Parse(respBody)
+			So(len(rCheck.Array()), ShouldEqual, 10)
+		})
+	})
+}

--- a/modules/f2e-api/test/api/alarm/run_test.sh
+++ b/modules/f2e-api/test/api/alarm/run_test.sh
@@ -1,0 +1,2 @@
+echo "events_test.go"
+go test -v events_test.go --test.run TestEvents


### PR DESCRIPTION
f2e-api getEvents 返回結果與實際預期不符

發現問題存在兩個問題, 需要修復:
* mysql 建議的使用方式是 timestamp between unixA and unixB (原本的寫法是timestamp >= unixA and timestamp <= unixB). sql 查詢仍會執行但是會有問題
* 換頁的作法會有一些bug

這個PR是修復以上列的兩個問題. 然後順便更新了一下test 的readme.

如何執行測試 （使用方法一）:
https://github.com/Cepave/open-falcon-backend/commit/7b023b4f08da889c52357159697c77218311ddd5
```
cd test/api/alarm
./run_test.sh
```
![image](https://user-images.githubusercontent.com/4387822/31652733-b164909c-b352-11e7-8136-0dbf3db8b3c2.png)
