### PR TITLE
[OWL-1986] disable ss -s metric collection in Agent

### DIFF
--- a/modules/agent/funcs/funcs.go
+++ b/modules/agent/funcs/funcs.go
@@ -50,6 +50,7 @@ func BuildMappers() {
 		{
 			Fs: []func() []*model.MetricValue{
 				PortMetrics,
+				// SocketStatSummaryMetrics,
 			},
 			Interval: interval,
 		},

--- a/modules/agent/funcs/funcs.go
+++ b/modules/agent/funcs/funcs.go
@@ -50,7 +50,6 @@ func BuildMappers() {
 		{
 			Fs: []func() []*model.MetricValue{
 				PortMetrics,
-				SocketStatSummaryMetrics,
 			},
 			Interval: interval,
 		},


### PR DESCRIPTION
關閉了下列的監控項的採集：

- ss.orphaned
- ss.closed
- ss.timewait
- ss.slabinfo.timewait
- ss.synrecv
- ss.estab

根據白金的實驗，在 loading 極高的設備，使用 ss -s 指令會產生許多的 system lock/mutex 影響系統的效能。